### PR TITLE
Add RISC-V support for gm.py-based builds

### DIFF
--- a/tools/dev/gm.py
+++ b/tools/dev/gm.py
@@ -36,9 +36,9 @@ BUILD_TARGETS_ALL = ["all"]
 
 # All arches that this script understands.
 ARCHES = ["ia32", "x64", "arm", "arm64", "mipsel", "mips64el", "ppc", "ppc64",
-          "s390", "s390x", "android_arm", "android_arm64"]
+          "riscv64", "s390", "s390x", "android_arm", "android_arm64"]
 # Arches that get built/run when you don't specify any.
-DEFAULT_ARCHES = ["ia32", "x64", "arm", "arm64"]
+DEFAULT_ARCHES = ["ia32", "x64", "arm", "arm64", "riscv64"]
 # Modes that this script understands.
 MODES = ["release", "debug", "optdebug"]
 # Modes that get built/run when you don't specify any.
@@ -243,7 +243,7 @@ class Config(object):
     if self.arch == "android_arm": return "\nv8_target_cpu = \"arm\""
     if self.arch == "android_arm64": return "\nv8_target_cpu = \"arm64\""
     if self.arch in ("arm", "arm64", "mipsel", "mips64el", "ppc", "ppc64",
-                     "s390", "s390x"):
+                     "riscv64", "s390", "s390x"):
       return "\nv8_target_cpu = \"%s\"" % self.arch
     return ""
 


### PR DESCRIPTION
I know the docs use gn, but I've been using gm.py as that's what the docs
suggest.  I don't actually know the difference between them.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>