### PR TITLE
Add support for cross compiling to riscv64

### DIFF
--- a/infra/mb/mb_config.pyl
+++ b/infra/mb/mb_config.pyl
@@ -33,6 +33,12 @@
       'ppc64.debug.sim': 'default_debug_ppc64_sim',
       'ppc64.optdebug.sim': 'default_optdebug_ppc64_sim',
       'ppc64.release.sim': 'default_release_ppc64_sim',
+      'riscv64.debug': 'default_debug_riscv64',
+      'riscv64.optdebug': 'default_optdebug_riscv64',
+      'riscv64.release': 'default_release_riscv64',
+      'riscv64.debug.sim': 'default_debug_riscv64_sim',
+      'riscv64.optdebug.sim': 'default_optdebug_riscv64_sim',
+      'riscv64.release.sim': 'default_release_riscv64_sim',
       's390x.debug': 'default_debug_s390x',
       's390x.optdebug': 'default_optdebug_s390x',
       's390x.release': 'default_release_s390x',
@@ -162,6 +168,8 @@
       # IBM.
       'V8 Linux - ppc64 - sim': 'release_simulate_ppc64',
       'V8 Linux - s390x - sim': 'release_simulate_s390x',
+      # RISC-V
+      'V8 Linux - riscv64 - sim': 'release_simulate_riscv64',
     },
     'client.v8.branches': {
       'V8 Linux - beta branch': 'release_x86',
@@ -182,6 +190,8 @@
       'V8 mipsel - sim - stable branch': 'release_simulate_mipsel',
       'V8 ppc64 - sim - beta branch': 'release_simulate_ppc64',
       'V8 ppc64 - sim - stable branch': 'release_simulate_ppc64',
+      'V8 riscv64 - sim - beta branch': 'release_simulate_riscv64',
+      'V8 riscv64 - sim - stable branch': 'release_simulate_riscv64',
       'V8 s390x - sim - beta branch': 'release_simulate_s390x',
       'V8 s390x - sim - stable branch': 'release_simulate_s390x',
     },
@@ -290,6 +300,18 @@
       'debug', 'simulate_mips64el', 'v8_enable_slow_dchecks'],
     'default_release_mips64el': [
       'release', 'simulate_mips64el'],
+    'default_debug_riscv64': [
+      'debug', 'riscv64', 'gcc', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+    'default_optdebug_riscv64': [
+      'debug', 'riscv64', 'gcc', 'v8_enable_slow_dchecks'],
+    'default_release_riscv64': [
+      'release', 'riscv64', 'gcc'],
+    'default_debug_riscv64_sim': [
+      'debug', 'simulate_riscv64', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+    'default_optdebug_riscv64_sim': [
+      'debug', 'simulate_riscv64', 'v8_enable_slow_dchecks'],
+    'default_release_riscv64_sim': [
+      'release', 'simulate_riscv64'],
     'default_debug_ppc64': [
       'debug', 'ppc64', 'gcc', 'v8_enable_slow_dchecks', 'v8_full_debug'],
     'default_optdebug_ppc64': [
@@ -375,6 +397,8 @@
       'release_bot', 'simulate_mips64el'],
     'release_simulate_ppc64': [
       'release_bot', 'simulate_ppc64'],
+    'release_simulate_riscv64': [
+      'release_bot', 'simulate_riscv64'],
     'release_simulate_s390x': [
       'release_bot', 'simulate_s390x'],
 
@@ -725,6 +749,10 @@
       'gn_args': 'target_cpu="x64" v8_target_cpu="ppc64"',
     },
 
+    'simulate_riscv64': {
+      'gn_args': 'target_cpu="x64" v8_target_cpu="riscv64"',
+    },
+
     'simulate_s390x': {
       'gn_args': 'target_cpu="x64" v8_target_cpu="s390x"',
     },
@@ -825,6 +853,10 @@
 
     'ppc64': {
       'gn_args': 'target_cpu="ppc64" use_custom_libcxx=false',
+    },
+
+    'riscv64': {
+      'gn_args': 'target_cpu="riscv64" use_custom_libcxx=false',
     },
 
     'x64': {

--- a/patches/build.patch
+++ b/patches/build.patch
@@ -1,61 +1,41 @@
 diff --git a/build_config.h b/build_config.h
-index d3cdd2db4..18f37cbbb 100644
+index d3cdd2db4..bd78845c3 100644
 --- a/build_config.h
 +++ b/build_config.h
-@@ -166,6 +166,20 @@
- #define ARCH_CPU_32_BITS 1
+@@ -124,6 +124,11 @@
+ #define ARCH_CPU_PPC64 1
+ #define ARCH_CPU_64_BITS 1
  #define ARCH_CPU_BIG_ENDIAN 1
- #endif
-+#elif defined(__riscv) || defined(__riscv__)
-+#if __riscv_xlen == 64
++#elif defined(__riscv) && (__riscv_xlen == 64)
 +#define ARCH_CPU_RISCV_FAMILY 1
 +#define ARCH_CPU_RISCV64 1
 +#define ARCH_CPU_64_BITS 1
 +#define ARCH_CPU_LITTLE_ENDIAN 1
-+#elif __riscv_xlen == 32
-+#define ARCH_CPU_RISCV_FAMILY 1
-+#define ARCH_CPU_RISCV32 1
-+#define ARCH_CPU_32_BITS 1
-+#define ARCH_CPU_LITTLE_ENDIAN 1
-+#else
-+#error "Cannot detect Riscv's bitwidth"
-+#endif
- #else
- #error Please add support for your architecture in build/build_config.h
- #endif
+ #elif defined(__PPC64__)
+ #define ARCH_CPU_PPC64_FAMILY 1
+ #define ARCH_CPU_PPC64 1
+diff --git a/config/BUILDCONFIG.gn b/config/BUILDCONFIG.gn
+index f89e7e831..f65e193d1 100644
+--- a/config/BUILDCONFIG.gn
++++ b/config/BUILDCONFIG.gn
+@@ -137,7 +137,8 @@ declare_args() {
+   is_clang = current_os != "linux" ||
+              (current_cpu != "s390x" && current_cpu != "s390" &&
+               current_cpu != "ppc64" && current_cpu != "ppc" &&
+-              current_cpu != "mips" && current_cpu != "mips64")
++              current_cpu != "mips" && current_cpu != "mips64" &&
++              current_cpu != "riscv64")
+ 
+   # Allows the path to a custom target toolchain to be injected as a single
+   # argument, and set as the default toolchain.
 diff --git a/toolchain/linux/BUILD.gn b/toolchain/linux/BUILD.gn
-index fa8b17e9d..f275e4dc5 100644
+index fa8b17e9d..ffb35e205 100644
 --- a/toolchain/linux/BUILD.gn
 +++ b/toolchain/linux/BUILD.gn
-@@ -65,6 +65,24 @@ gcc_toolchain("arm") {
+@@ -83,6 +83,14 @@ clang_toolchain("clang_x86_v8_arm") {
    }
  }
-
-+gcc_toolchain("riscv64") {
-+  toolprefix = "riscv64-unknown-linux-gnu-"
-+
-+  cc = "${toolprefix}gcc"
-+  cxx = "${toolprefix}g++"
-+
-+  ar = "${toolprefix}ar"
-+  ld = cxx
-+  readelf = "${toolprefix}readelf"
-+  nm = "${toolprefix}nm"
-+
-+  toolchain_args = {
-+    current_cpu = "riscv64"
-+    current_os = "linux"
-+    is_clang = false
-+  }
-+}
-+
- clang_toolchain("clang_x86") {
-   # Output linker map files for binary size analysis.
-   enable_linker_map = true
-@@ -136,6 +154,14 @@ clang_toolchain("clang_x64_v8_arm64") {
-   }
- }
-
+ 
 +clang_toolchain("clang_x64_v8_riscv64") {
 +  toolchain_args = {
 +    current_cpu = "x64"
@@ -64,6 +44,31 @@ index fa8b17e9d..f275e4dc5 100644
 +  }
 +}
 +
- clang_toolchain("clang_x64_v8_mips64el") {
+ clang_toolchain("clang_x86_v8_mipsel") {
    toolchain_args = {
-     current_cpu = "x64"
+     current_cpu = "x86"
+@@ -263,6 +271,24 @@ gcc_toolchain("ppc64") {
+   }
+ }
+ 
++gcc_toolchain("riscv64") {
++  toolprefix = "riscv64-linux-gnu"
++
++  cc = "${toolprefix}-gcc"
++  cxx = "${toolprefix}-g++"
++
++  readelf = "${toolprefix}-readelf"
++  nm = "${toolprefix}-nm"
++  ar = "${toolprefix}-ar"
++  ld = cxx
++
++  toolchain_args = {
++    current_cpu = "riscv64"
++    current_os = "linux"
++    is_clang = false
++  }
++}
++
+ gcc_toolchain("mips") {
+   toolprefix = "mips-linux-gnu-"
+ 

--- a/src/codegen/riscv64/macro-assembler-riscv64.h
+++ b/src/codegen/riscv64/macro-assembler-riscv64.h
@@ -1136,7 +1136,6 @@ void TurboAssembler::GenerateSwitchTable(Register index, size_t case_count,
   UseScratchRegisterScope temps(this);
   Register scratch = temps.Acquire();
 
-  Label here;
   Align(8);
   // Load the address from the jump table at index and jump to it
   auipc(scratch, 0);                  // Load the current PC into scratch

--- a/src/execution/riscv64/simulator-riscv64.cc
+++ b/src/execution/riscv64/simulator-riscv64.cc
@@ -46,11 +46,11 @@
 #if defined(USE_SIMULATOR)
 
 #include <limits.h>
+#include <math.h>
 #include <stdarg.h>
 #include <stdlib.h>
 
 #include <cfenv>
-#include <cmath>
 
 #include "src/base/bits.h"
 #include "src/codegen/assembler-inl.h"
@@ -1855,10 +1855,10 @@ float Simulator::RoundF2FHelper(float input_val, int rmode) {
       rounded = std::truncf(input_val);
       break;
     case RDN:  // Round Down (towards -infinity)
-      rounded = std::floorf(input_val);
+      rounded = floorf(input_val);
       break;
     case RUP:  // Round Up (towards +infinity)
-      rounded = std::ceilf(input_val);
+      rounded = ceilf(input_val);
       break;
     case RMM:  // Round to Nearest, tiest to Max Magnitude
       rounded = std::roundf(input_val);

--- a/test/cctest/test-assembler-riscv64.cc
+++ b/test/cctest/test-assembler-riscv64.cc
@@ -26,6 +26,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>  // NOLINT(readability/streams)
+#include <math.h>
 
 #include "src/init/v8.h"
 
@@ -700,7 +701,7 @@ UTEST_R2_FORM_WITH_OP_F(fadd_s, float, -1012.01f, 3456.13f, +)
 UTEST_R2_FORM_WITH_OP_F(fsub_s, float, -1012.01f, 3456.13f, -)
 UTEST_R2_FORM_WITH_OP_F(fmul_s, float, -10.01f, 56.13f, *)
 UTEST_R2_FORM_WITH_OP_F(fdiv_s, float, -10.01f, 34.13f, /)
-UTEST_R1_FORM_WITH_RES_F(fsqrt_s, float, 34.13f, std::sqrtf(34.13f))
+UTEST_R1_FORM_WITH_RES_F(fsqrt_s, float, 34.13f, sqrtf(34.13f))
 UTEST_R2_FORM_WITH_RES_F(fmin_s, float, -1012.0f, 3456.13f, -1012.0f)
 UTEST_R2_FORM_WITH_RES_F(fmax_s, float, -1012.0f, 3456.13f, 3456.13f)
 UTEST_R3_FORM_WITH_RES_F(fmadd_s, float, 67.56f, -1012.01f, 3456.13f,

--- a/test/unittests/compiler/riscv64/instruction-selector-riscv64-unittest.cc
+++ b/test/unittests/compiler/riscv64/instruction-selector-riscv64-unittest.cc
@@ -10,7 +10,7 @@ namespace v8 {
 namespace internal {
 namespace compiler {
 
-namespace {
+namespace tests {
 template <typename T>
 struct MachInst {
   T constructor;
@@ -296,7 +296,9 @@ const MachInst2 kCanElideChangeUint32ToUint64[] = {
     {&RawMachineAssembler::Uint32MulHigh, "Uint32MulHigh", kRiscvMulHighU,
      MachineType::Uint32()}};
 
-}  // namespace
+}  // namespace tests
+
+using namespace tests;
 
 using InstructionSelectorFPCmpTest = InstructionSelectorTestWithParam<FPCmp>;
 
@@ -1231,7 +1233,7 @@ TEST_F(InstructionSelectorTest, ChangeUint32ToUint64AfterLoad) {
 // ----------------------------------------------------------------------------
 
 
-namespace {
+namespace load_store {
 
 struct MemoryAccess {
   MachineType type;
@@ -1439,7 +1441,9 @@ const MemoryAccessImm2 kMemoryAccessesImmUnaligned[] = {
       39,    52,    69,    71,    91,    92,    107,   109,  115,  124,
       286,   655,   1362,  1569,  2587,  3067,  3096,  3462, 3510, 4095}}};
 
-}  // namespace
+}  // namespace load_store
+
+using namespace load_store;
 
 using InstructionSelectorMemoryAccessTest =
     InstructionSelectorTestWithParam<MemoryAccess>;


### PR DESCRIPTION
I've yet to figure out all the internal binary tools so I can't build natively, but with this I can at least get a cross compiled version up and running.  Simple stuff seems to work (console.log("hello, world"); 1.1) but I've yet to get the cross test suite running.  I'm using GCC for the build, as that seems to be the default for most systems and our LLVM port is a bit on the new side.