### PR TITLE
RISC-V: Add instruction cache flushing

### DIFF
--- a/src/codegen/riscv64/assembler-riscv64.cc
+++ b/src/codegen/riscv64/assembler-riscv64.cc
@@ -1125,10 +1125,6 @@ void Assembler::fence_tso() {
   GenInstrI(0b000, MISC_MEM, ToRegister(0), ToRegister(0), imm12);
 }
 
-void Assembler::fence_i() {
-  GenInstrI(0b001, MISC_MEM, ToRegister(0), ToRegister(0), 0);
-}
-
 // Environment call / break
 
 void Assembler::ecall() {

--- a/src/codegen/riscv64/assembler-riscv64.h
+++ b/src/codegen/riscv64/assembler-riscv64.h
@@ -407,7 +407,6 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   // Memory fences
   void fence(uint8_t pred, uint8_t succ);
   void fence_tso();
-  void fence_i();
 
   // Environment call / break
   void ecall();

--- a/src/codegen/riscv64/cpu-riscv64.cc
+++ b/src/codegen/riscv64/cpu-riscv64.cc
@@ -16,22 +16,7 @@ namespace internal {
 
 void CpuFeatures::FlushICache(void* start, size_t size) {
 #if !defined(USE_SIMULATOR)
-  // Nothing to do, flushing no instructions.
-  if (size == 0) {
-    return;
-  }
-
-#if defined(ANDROID) && !defined(__LP64__)
-  // Bionic cacheflush can typically run in userland, avoiding kernel call.
-  char* end = reinterpret_cast<char*>(start) + size;
-  cacheflush(reinterpret_cast<intptr_t>(start), reinterpret_cast<intptr_t>(end),
-             0);
-#else   // ANDROID
-  long res;  // NOLINT(runtime/int)
-  // FIXME: RISCV porting
-  res = 0;
-  if (res) FATAL("Failed to flush the instruction cache");
-#endif  // ANDROID
+  __builtin___clear_cache(start, (char *)start + size);
 #endif  // !USE_SIMULATOR.
 }
 

--- a/test/cctest/test-assembler-riscv64.cc
+++ b/test/cctest/test-assembler-riscv64.cc
@@ -616,7 +616,6 @@ UTEST_R2_FORM_WITH_OP(sra, int64_t, -0x1234'5678'0000'0000LL, 33, >>)
 // -- Memory fences --
 // void fence(uint8_t pred, uint8_t succ);
 // void fence_tso();
-// void fence_i();
 
 // -- Environment call / break --
 // void ecall();

--- a/test/cctest/test-disasm-riscv64.cc
+++ b/test/cctest/test-disasm-riscv64.cc
@@ -168,7 +168,6 @@ TEST(MISC) {
   // Memory fences
   COMPARE(fence(PSO | PSR, PSW | PSI), "0690000f       fence or, iw");
   COMPARE(fence_tso(), "8330000f       fence rw, rw");
-  COMPARE(fence_i(), "0000100f       fence.i");
 
   // Environment call / break
   COMPARE(ecall(), "00000073       ecall");


### PR DESCRIPTION
I know the ISA manual says fence.i in it, and that the older versions say it's
in I, but it's not and you can't use it from userspace in Linux (at least, if
you want your programs to work).  It's currently implemented as a system call,
but as there may eventually be something faster you should use the GCC builtin
instead.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>