### PR TITLE
Implementaion of MulOverflow is error. 

### DIFF
--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -466,14 +466,14 @@ void TurboAssembler::Dsubu(Register rd, Register rs, const Operand& rt) {
 
 void TurboAssembler::Mul(Register rd, Register rs, const Operand& rt) {
   if (rt.is_reg()) {
-    mulw(rd, rs, rt.rm());
+    mul(rd, rs, rt.rm());
   } else {
     // li handles the relocation.
     UseScratchRegisterScope temps(this);
     Register scratch = temps.Acquire();
     DCHECK(rs != scratch);
     RV_li(scratch, rt.immediate());
-    mulw(rd, rs, scratch);
+    mul(rd, rs, scratch);
   }
 }
 


### PR DESCRIPTION
On mips64, 32-bit mul has two instr:mul and muh. But on riscv64 only have one instr:mulw.
So when run `./cctest test-macro-assembler-riscv64/OverflowInstructions`,  MulOverflow32 case pass failed on riscv-linux qemu.


