### PR TITLE
mulw sign extends its inputs

### DIFF
--- a/src/execution/riscv64/simulator-riscv64.cc
+++ b/src/execution/riscv64/simulator-riscv64.cc
@@ -1775,7 +1775,7 @@ void Simulator::DecodeRVRType() {
     }
 #ifdef V8_TARGET_ARCH_64_BIT
     case RO_MULW: {
-      set_rd(sext32(rs1() * rs2()));
+      set_rd(sext32(sext32(rs1()) * sext32(rs2())));
       break;
     }
     case RO_DIVW: {


### PR DESCRIPTION
This doesn't change any test suite failures, but it does match what the ISA
does and I'm assuming that as we sort out the mul/mulh differences between
RISC-V and MIPS that this will become relevant.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>