### PR TITLE
Rplace the expected value of a floating point calculation with an exact  value.

### DIFF
--- a/src/execution/riscv64/simulator-riscv64.cc
+++ b/src/execution/riscv64/simulator-riscv64.cc
@@ -2701,7 +2701,7 @@ void Simulator::DecodeRVR4Type() {
           this->set_fflags(kInvalidOperation);
           return std::numeric_limits<float>::quiet_NaN();
         } else {
-          return frs1 * frs2 + frs3;
+          return std::fma(frs1, frs2, frs3);
         }
       };
       set_frd(CanonicalizeFPUOp3<float>(fn));
@@ -2714,7 +2714,7 @@ void Simulator::DecodeRVR4Type() {
           this->set_fflags(kInvalidOperation);
           return std::numeric_limits<float>::quiet_NaN();
         } else {
-          return frs1 * frs2 - frs3;
+          return std::fma(frs1, frs2, -frs3);
         }
       };
       set_frd(CanonicalizeFPUOp3<float>(fn));
@@ -2727,7 +2727,7 @@ void Simulator::DecodeRVR4Type() {
           this->set_fflags(kInvalidOperation);
           return std::numeric_limits<float>::quiet_NaN();
         } else {
-          return -(frs1 * frs2) + frs3;
+          return -std::fma(frs1, frs2, -frs3);
         }
       };
       set_frd(CanonicalizeFPUOp3<float>(fn));
@@ -2740,7 +2740,7 @@ void Simulator::DecodeRVR4Type() {
           this->set_fflags(kInvalidOperation);
           return std::numeric_limits<float>::quiet_NaN();
         } else {
-          return -(frs1 * frs2) - frs3;
+          return -std::fma(frs1, frs2, frs3);
         }
       };
       set_frd(CanonicalizeFPUOp3<float>(fn));

--- a/src/execution/riscv64/simulator-riscv64.cc
+++ b/src/execution/riscv64/simulator-riscv64.cc
@@ -2754,7 +2754,7 @@ void Simulator::DecodeRVR4Type() {
           this->set_fflags(kInvalidOperation);
           return std::numeric_limits<double>::quiet_NaN();
         } else {
-          return drs1 * drs2 + drs3;
+          return std::fma(drs1, drs2, drs3);
         }
       };
       set_drd(CanonicalizeFPUOp3<double>(fn));
@@ -2767,7 +2767,7 @@ void Simulator::DecodeRVR4Type() {
           this->set_fflags(kInvalidOperation);
           return std::numeric_limits<double>::quiet_NaN();
         } else {
-          return drs1 * drs2 - drs3;
+          return std::fma(drs1, drs2, -drs3);
         }
       };
       set_drd(CanonicalizeFPUOp3<double>(fn));
@@ -2780,7 +2780,7 @@ void Simulator::DecodeRVR4Type() {
           this->set_fflags(kInvalidOperation);
           return std::numeric_limits<double>::quiet_NaN();
         } else {
-          return -(drs1 * drs2) + drs3;
+          return -std::fma(drs1, drs2, -drs3);
         }
       };
       set_drd(CanonicalizeFPUOp3<double>(fn));
@@ -2793,7 +2793,7 @@ void Simulator::DecodeRVR4Type() {
           this->set_fflags(kInvalidOperation);
           return std::numeric_limits<double>::quiet_NaN();
         } else {
-          return -(drs1 * drs2) - drs3;
+          return -std::fma(drs1, drs2, drs3);
         }
       };
       set_drd(CanonicalizeFPUOp3<double>(fn));

--- a/test/cctest/test-assembler-riscv64.cc
+++ b/test/cctest/test-assembler-riscv64.cc
@@ -705,13 +705,13 @@ UTEST_R1_FORM_WITH_RES_F(fsqrt_s, float, 34.13f, sqrtf(34.13f))
 UTEST_R2_FORM_WITH_RES_F(fmin_s, float, -1012.0f, 3456.13f, -1012.0f)
 UTEST_R2_FORM_WITH_RES_F(fmax_s, float, -1012.0f, 3456.13f, 3456.13f)
 UTEST_R3_FORM_WITH_RES_F(fmadd_s, float, 67.56f, -1012.01f, 3456.13f,
-                         (67.56f * (-1012.01f) + 3456.13f))
+                         std::fma(67.56f, -1012.01f, 3456.13f))
 UTEST_R3_FORM_WITH_RES_F(fmsub_s, float, 67.56f, -1012.01f, 3456.13f,
-                         (67.56f * (-1012.01f) - 3456.13f))
+                         std::fma(67.56f, -1012.01f, -3456.13f))
 UTEST_R3_FORM_WITH_RES_F(fnmsub_s, float, 67.56f, -1012.01f, 3456.13f,
-                         (-(67.56f * (-1012.01f)) + 3456.13f))
+                         -std::fma(67.56f, -1012.01f, -3456.13f))
 UTEST_R3_FORM_WITH_RES_F(fnmadd_s, float, 67.56f, -1012.01f, 3456.13f,
-                         (-(67.56f * (-1012.01f)) - 3456.13f))
+                         -std::fma(67.56f, -1012.01f, 3456.13f))
 UTEST_COMPARE_WITH_OP_F(feq_s, float, -3456.56, -3456.56, ==)
 UTEST_COMPARE_WITH_OP_F(flt_s, float, -3456.56, -3456.56, <)
 UTEST_COMPARE_WITH_OP_F(fle_s, float, -3456.56, -3456.56, <=)
@@ -736,13 +736,13 @@ UTEST_R2_FORM_WITH_RES_F(fmin_d, double, -1012.0, 3456.13, -1012.0)
 UTEST_R2_FORM_WITH_RES_F(fmax_d, double, -1012.0, 3456.13, 3456.13)
 
 UTEST_R3_FORM_WITH_RES_F(fmadd_d, double, 67.56, -1012.01, 3456.13,
-                         (67.56 * (-1012.01) + 3456.13))
+                         std::fma(67.56, -1012.01, 3456.13))
 UTEST_R3_FORM_WITH_RES_F(fmsub_d, double, 67.56, -1012.01, 3456.13,
-                         (67.56 * (-1012.01) - 3456.13))
+                         std::fma(67.56, -1012.01, -3456.13))
 UTEST_R3_FORM_WITH_RES_F(fnmsub_d, double, 67.56, -1012.01, 3456.13,
-                         (-(67.56 * (-1012.01)) + 3456.13))
+                         -std::fma(67.56, -1012.01, -3456.13))
 UTEST_R3_FORM_WITH_RES_F(fnmadd_d, double, 67.56, -1012.01, 3456.13,
-                         (-(67.56 * (-1012.01)) - 3456.13))
+                         -std::fma(67.56, -1012.01, 3456.13))
 
 UTEST_COMPARE_WITH_OP_F(feq_d, double, -3456.56, -3456.56, ==)
 UTEST_COMPARE_WITH_OP_F(flt_d, double, -3456.56, -3456.56, <)


### PR DESCRIPTION
Computer calculates  floating-point numbers is always inaccurate, so should manually calculate the expected value.