### PR TITLE
Modify the judgment of integer range

### DIFF
--- a/src/compiler/backend/riscv64/code-generator-riscv64.cc
+++ b/src/compiler/backend/riscv64/code-generator-riscv64.cc
@@ -2194,7 +2194,7 @@ void CodeGenerator::AssembleArchBoolean(Instruction* instr,
         Register left = i.InputRegister(0);
         Operand right = i.InputOperand(1);
         if (instr->InputAt(1)->IsImmediate()) {
-          if (is_int16(-right.immediate())) {
+          if (is_int12(-right.immediate())) {
             if (right.immediate() == 0) {
               if (cc == eq) {
                 __ Sltu(result, left, 1);
@@ -2210,7 +2210,7 @@ void CodeGenerator::AssembleArchBoolean(Instruction* instr,
               }
             }
           } else {
-            if (is_uint16(right.immediate())) {
+            if (is_uint12(right.immediate())) {
               __ Xor(result, left, right);
             } else {
               __ li(kScratchReg, right);


### PR DESCRIPTION
Change is_int16 to is_int12, and is_uint16 to is_uint12.
It will not cause any errors using is_int16/is_uint16, because it make a
further judgment in TurboAssembler. But I think it makes the judgment
meaningless.