### PR TITLE
On riscv64, branch long can using only 2 instr:auipc+jalr.

### DIFF
--- a/src/codegen/riscv64/assembler-riscv64.h
+++ b/src/codegen/riscv64/assembler-riscv64.h
@@ -641,6 +641,8 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   void jal(int32_t imm21) { jal(ToRegister(1), imm21); }
   inline void jal(Label* L) { jal(jump_offset(L)); }
   void jr(Register rs) { jalr(zero_reg, rs, 0); }
+  void jr(Register rs, int32_t imm12) { jalr(zero_reg, rs, imm12); }
+  void jalr(Register rs, int32_t imm12) { jalr(ToRegister(1), rs, imm12); }
   void jalr(Register rs) { jalr(ToRegister(1), rs, 0); }
   void ret() { jalr(zero_reg, ToRegister(1), 0); }
   void call(int32_t offset) {

--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -3182,10 +3182,10 @@ void TurboAssembler::BranchLong(Label* L) {
     int64_t imm64;
     imm64 = branch_long_offset(L);
     DCHECK(is_int32(imm64));
-    auipc(t5, 0);  // Read PC into t5.
-    RV_li(t6, imm64);
-    add(t6, t5, t6);
-    jr(t6);
+    int32_t Hi20 = (((int32_t)imm64 + 0x800) >> 12);
+    int32_t Lo12 = (int32_t)imm64 << 20 >> 20;
+    auipc(t5, Hi20);  // Read PC + Hi20 into t5.
+    jr(t5, Lo12);   // jump PC + Hi20 + Lo12
   }
 }
 
@@ -3198,10 +3198,10 @@ void TurboAssembler::BranchAndLinkLong(Label* L) {
     int64_t imm64;
     imm64 = branch_long_offset(L);
     DCHECK(is_int32(imm64));
-    auipc(ra, 0);  // Read PC into ra register.
-    RV_li(t5, imm64);
-    add(t5, ra, t5);
-    jalr(t5);
+    int32_t Hi20 = (((int32_t)imm64 + 0x800) >> 12);
+    int32_t Lo12 = (int32_t)imm64 << 20 >> 20;
+    auipc(t5, Hi20);  // Read PC + Hi20 into t5.
+    jalr(t5, Lo12);   // jump PC + Hi20 + Lo12 and read PC + 4 to ra
   }
 }
 


### PR DESCRIPTION
On riscv64, branch long only using 2 instr auipc+jalr. Refer to [The RISC-V Instruction Set Manual](https://riscv.org/specifications/)