### PR TITLE
Fix break command in simulator

### DIFF
--- a/src/execution/riscv64/simulator-riscv64.h
+++ b/src/execution/riscv64/simulator-riscv64.h
@@ -568,6 +568,18 @@ class Simulator : public SimulatorBase {
   // Used for breakpoints and traps.
   void SoftwareInterrupt();
 
+  // Debug helpers
+
+  // Simulator breakpoints.
+  struct Breakpoint {
+    Instruction* location;
+    bool enabled;
+  };
+  std::vector<Breakpoint> breakpoints_;
+  void SetBreakpoint(Instruction* breakpoint);
+  void ListBreakpoints();
+  void CheckBreakpoints();
+
   // Stop helper functions.
   bool IsWatchpoint(uint64_t code);
   void PrintWatchpoint(uint64_t code);

--- a/src/execution/riscv64/simulator-riscv64.h
+++ b/src/execution/riscv64/simulator-riscv64.h
@@ -574,9 +574,10 @@ class Simulator : public SimulatorBase {
   struct Breakpoint {
     Instruction* location;
     bool enabled;
+    bool temporary;
   };
   std::vector<Breakpoint> breakpoints_;
-  void SetBreakpoint(Instruction* breakpoint);
+  void SetBreakpoint(Instruction* breakpoint, bool temporary);
   void ListBreakpoints();
   void CheckBreakpoints();
 

--- a/src/execution/riscv64/simulator-riscv64.h
+++ b/src/execution/riscv64/simulator-riscv64.h
@@ -574,10 +574,10 @@ class Simulator : public SimulatorBase {
   struct Breakpoint {
     Instruction* location;
     bool enabled;
-    bool temporary;
+    bool is_tbreak;
   };
   std::vector<Breakpoint> breakpoints_;
-  void SetBreakpoint(Instruction* breakpoint, bool temporary);
+  void SetBreakpoint(Instruction* breakpoint, bool is_tbreak);
   void ListBreakpoints();
   void CheckBreakpoints();
 

--- a/src/execution/riscv64/simulator-riscv64.h
+++ b/src/execution/riscv64/simulator-riscv64.h
@@ -643,10 +643,6 @@ class Simulator : public SimulatorBase {
 
   v8::internal::Isolate* isolate_;
 
-  // Registered breakpoints.
-  Instruction* break_pc_;
-  Instr break_instr_;
-
   // Stop is disabled if bit 31 is set.
   static const uint32_t kStopDisabledBit = 1 << 31;
 


### PR DESCRIPTION
The `break` command problem is caused by a method that triggers write protection, which is `SetInstructionBits`.

```
// Set the raw instruction bits to value.
  inline void SetInstructionBits(Instr value) {
    *reinterpret_cast<Instr*>(this) = value;
  }
```

Not only the riscv64 simulator, any simulator based on arm32 would have this problem (at least mips64 simulator which I have tested).

As mentioned in [V8 dev](https://v8.dev/docs/debug-arm#test.js)

> you'll need to disable write protection on code pages to insert it.

But it seems difficult to do that.

Luckily, arm64 simulator doesn't have this problem which architecture is different from arm32 simulator.

So I applied the idea from arm64 simulator to enable the `break` command.

This change is a minimal change in order to support developers as soon as possible. As a option, we could refactor the riscv64 simulator based on arm64 simulator in future.

Besides, this change of `break` would enable some other commands like `next` which I think maybe useful. I will enable things like that when I finish dealing with `stop` and `gdb` commands in #5 .
