### PR TITLE
RFC: Enable fuzzers

### DIFF
--- a/test/fuzzer/testcfg.py
+++ b/test/fuzzer/testcfg.py
@@ -16,7 +16,7 @@ SUB_TESTS = [
   'wasm',
   'wasm_async',
   'wasm_code',
-  'wasm_compile',
+  'wasm_compile'
 ]
 
 class VariantsGenerator(testsuite.VariantsGenerator):
@@ -28,6 +28,9 @@ class TestLoader(testsuite.GenericTestLoader):
   @property
   def test_dirs(self):
     return SUB_TESTS
+  
+  def _should_filter_by_name(self, filename):
+    return False
 
   def _to_relpath(self, abspath, _):
     return os.path.relpath(abspath, self.suite.root)

--- a/test/fuzzer/testcfg.py
+++ b/test/fuzzer/testcfg.py
@@ -16,7 +16,7 @@ SUB_TESTS = [
   'wasm',
   'wasm_async',
   'wasm_code',
-  'wasm_compile'
+  'wasm_compile',
 ]
 
 class VariantsGenerator(testsuite.VariantsGenerator):


### PR DESCRIPTION
I found that class TestLoader of fuzzer/testcfg.py extends testsuite.GenericTestLoader, but each loaded file will be filtered when we execute "tools/run-tests.py --outdir=out/x64.release fuzzer ". #6 

Other class TestLoader like the one in mjsunit/testcfg.py which configure mjsunit just extends testsuite.JSTestLoader. And JSTestLoader also extends testsuit.GenericTestLoader but overrides method extensions for .js files. 
``` py
class JSTestLoader(GenericTestLoader):
  @property
  def extensions(self):
    return [".js", ".mjs"]
```
Then _should_filter_by_name method can load .js or .mjs test files for fuzzer.
``` py
  def _should_filter_by_name(self, filename):
    if not self.__find_extension(filename):
      return True

    for suffix in self.excluded_suffixes:
      if filename.endswith(suffix):
        return True

    if os.path.basename(filename) in self.excluded_files:
      return True

    return False
```

So if we want to enable fuzzer, the only thing we can do is to override method  _should_filter_by_name of TestLoader.

Actually, I'm not sure if it's a bug of fuzzer test script. Maybe there's something that I didn't notice. 
