### PR TITLE
Optimize TurboAssembler::Ext32

### DIFF
--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -1612,7 +1612,9 @@ void TurboAssembler::Ext32(Register rt, Register rs, uint16_t pos,
   DCHECK_LT(pos + size, 33);
   // RISC-V does not have an extract-type instruction, so we need to use shifts
   slliw(rt, rs, 32 - (pos + size));
-  srliw(rt, rt, 32 - size);
+  if (size != 32) {
+    srliw(rt, rt, 32 - size);
+  }
 }
 
 void TurboAssembler::Ext64(Register rt, Register rs, uint16_t pos,


### PR DESCRIPTION
In "TurboAssembler::Ext32", when size is 32, it will generate following two instructions:
1. slliw rt, rs, 0
2. srliw rt, rt, 0  

The first instruction with a zero shift amount truncates a 64-bit value to 32
bits and sign-extends it. The second instruction with a zero shift amount is
redundant.  

An example of size is 32: In "InstructionSelector::VisitTruncateInt64ToInt32",  it emit instruction using "Emit(kRiscvExt32, g.DefineAsRegister(node), g.UseRegister(node->InputAt(0)),    g.TempImmediate(0), g.TempImmediate(32));" , which calls "TurboAssembler::Ext32" in code generator, with pos 0, and size 32.


