### PR TITLE
Fix compiling issue for test-macro-assembler-riscv64.cc

### DIFF
--- a/test/cctest/test-macro-assembler-riscv64.cc
+++ b/test/cctest/test-macro-assembler-riscv64.cc
@@ -1477,7 +1477,7 @@ int32_t run_CompareF(IN_TYPE x1, IN_TYPE x2, bool expected_res,
   MacroAssembler assm(isolate, v8::internal::CodeObjectRequired::kYes);
   MacroAssembler* masm = &assm;
 
-  Label error, done;
+  Label done;
 
   // Vararg f.Call() passes floating-point params via GPRs, so move arguments to
   // FPRs first


### PR DESCRIPTION
Unused variable, Label error, in test-macro-assembler-riscv64.cc causes
the compilation to fail. This commit removes that variable.

Resolves #64