### PR TITLE
Fix register allocation for wasm compiler

### DIFF
--- a/src/codegen/riscv64/register-riscv64.h
+++ b/src/codegen/riscv64/register-riscv64.h
@@ -336,12 +336,13 @@ constexpr Register kJavaScriptCallCodeStartRegister = a2;
 constexpr Register kJavaScriptCallTargetRegister = kJSFunctionRegister;
 constexpr Register kJavaScriptCallNewTargetRegister = a3;
 constexpr Register kJavaScriptCallExtraArg1Register = a2;
+
 constexpr Register kOffHeapTrampolineRegister = t3;
 constexpr Register kRuntimeCallFunctionRegister = a1;
 constexpr Register kRuntimeCallArgCountRegister = a0;
 constexpr Register kRuntimeCallArgvRegister = a2;
 constexpr Register kWasmInstanceRegister = a0;
-constexpr Register kWasmCompileLazyFuncIndexRegister = a4;
+constexpr Register kWasmCompileLazyFuncIndexRegister = t0;
 
 }  // namespace internal
 }  // namespace v8

--- a/test/mjsunit/mjsunit.status
+++ b/test/mjsunit/mjsunit.status
@@ -832,11 +832,9 @@
 
 ['arch == riscv64 or arch == riscv', {
   'regress/wasm/regress-1032753': [SKIP], # issue 57
-  'regress/regress-6196': [SKIP], # issue 54
-  'es6/block-conflicts-sloppy': [SKIP], #issue 56
-  
-  'wasm/asm-wasm': [SKIP], # issue 54
-  'wasm/compilation-hints-interpreter': [SKIP], # issue 54
+  'es6/block-conflicts-sloppy': [SKIP], # issue 56
+  'es6/promises': [SKIP], # issue 56
+
   'wasm/compiled-module-serialization': [SKIP], # issue 55
   'wasm/float-constant-folding': [SKIP], # issue 53
   'wasm/shared-memory-gc-stress': [SKIP], # issue 56


### PR DESCRIPTION
Register `a4` was previously assigned as a temp register for the wasm
compiler, causing an error when that was being used as an argument. This
changes that back to using `t0`.

Fixes #54