### PR TITLE
Fix stop command & remove unused code for stop command

### DIFF
--- a/src/codegen/riscv64/assembler-riscv64.cc
+++ b/src/codegen/riscv64/assembler-riscv64.cc
@@ -1820,8 +1820,6 @@ void Assembler::break_(uint32_t code, bool break_as_stop) {
   // since ebreak does not allow additional immediate field, we use the
   // immediate field of lui instruction immediately following the ebreak to
   // encode the "code" info
-  //
-  // FIXME: need to check how native debugger gets the "code" information
   ebreak();
   DCHECK(is_uint20(code));
   lui(zero_reg, code);

--- a/src/execution/riscv64/simulator-riscv64.h
+++ b/src/execution/riscv64/simulator-riscv64.h
@@ -584,7 +584,7 @@ class Simulator : public SimulatorBase {
   // Stop helper functions.
   bool IsWatchpoint(uint64_t code);
   void PrintWatchpoint(uint64_t code);
-  void HandleStop(uint64_t code, Instruction* instr);
+  void HandleStop(uint64_t code);
   bool IsStopInstruction(Instruction* instr);
   bool IsEnabledStop(uint64_t code);
   void EnableStop(uint64_t code);


### PR DESCRIPTION
Now the `stop` command could work like the comment in `constants-riscv64.h` #5 

```
// On RISC-V Simulator breakpoints can have different codes:
// - Breaks between 0 and kMaxWatchpointCode are treated as simple watchpoints,
//   the simulator will run through them and print the registers.
// - Breaks between kMaxWatchpointCode and kMaxStopCode are treated as stop()
//   instructions (see Assembler::stop()).
// - Breaks larger than kMaxStopCode are simple breaks, dropping you into the
//   debugger.
```