### PR TITLE
Fix cache error

### DIFF
--- a/src/codegen/riscv64/cpu-riscv64.cc
+++ b/src/codegen/riscv64/cpu-riscv64.cc
@@ -16,7 +16,9 @@ namespace internal {
 
 void CpuFeatures::FlushICache(void* start, size_t size) {
 #if !defined(USE_SIMULATOR)
-  __builtin___clear_cache(start, (char *)start + size);
+  // FIXME(RISCV): builtin_clear_cache doesn't work yet, so use `fence.i` for now
+  // __builtin___clear_cache(start, (char *)start + size);
+  asm volatile("fence.i" ::: "memory");
 #endif  // !USE_SIMULATOR.
 }
 


### PR DESCRIPTION
Fix #71 :In riscv64, should use `fence.i` to synchronize the instruction and data streams. Refer to `The RISC-V Instruction Set Manual
Volume I: Unprivileged ISA.`