### PR TITLE
On riscv, uint32 always is signed extened.

### DIFF
--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -500,7 +500,7 @@ void TurboAssembler::Mulhu32(Register rd, Register rs, const Operand& rt,
   else
     RV_li(rtz, rt.immediate() << 32);
   mulhu(rd, rsz, rtz);
-  srli(rd, rd, 32);
+  srai(rd, rd, 32);
 }
 
 void TurboAssembler::Mul64(Register rd, Register rs, const Operand& rt) {

--- a/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
+++ b/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
@@ -1284,14 +1284,6 @@ void InstructionSelector::VisitChangeUint32ToUint64(Node* node) {
   RiscvOperandGenerator g(this);
   Node* value = node->InputAt(0);
   switch (value->opcode()) {
-    // 32-bit operations will write their result in a 64 bit register,
-    // clearing the top 32 bits of the destination register.
-    case IrOpcode::kUint32Div:
-    case IrOpcode::kUint32Mod:
-    case IrOpcode::kUint32MulHigh: {
-      Emit(kArchNop, g.DefineSameAsFirst(node), g.Use(value));
-      return;
-    }
     case IrOpcode::kLoad: {
       LoadRepresentation load_rep = LoadRepresentationOf(value->op());
       if (load_rep.IsUnsigned()) {

--- a/test/unittests/compiler/riscv64/instruction-selector-riscv64-unittest.cc
+++ b/test/unittests/compiler/riscv64/instruction-selector-riscv64-unittest.cc
@@ -1130,8 +1130,8 @@ TEST_P(InstructionSelectorElidedChangeUint32ToUint64Test, Parameter) {
   m.Return(m.ChangeUint32ToUint64(
       (m.*binop.constructor)(m.Parameter(0), m.Parameter(1))));
   Stream s = m.Build();
-  // Make sure the `ChangeUint32ToUint64` node turned into a no-op.
-  ASSERT_EQ(1U, s.size());
+  // Make sure the `ChangeUint32ToUint64` node turned into two op(sli 32 and sri 32).
+  ASSERT_EQ(2U, s.size());
   EXPECT_EQ(binop.arch_opcode, s[0]->arch_opcode());
   EXPECT_EQ(2U, s[0]->InputCount());
   EXPECT_EQ(1U, s[0]->OutputCount());


### PR DESCRIPTION
    Fix: #73