### PR TITLE
fix-75 atomic

### DIFF
--- a/src/compiler/backend/riscv64/code-generator-riscv64.cc
+++ b/src/compiler/backend/riscv64/code-generator-riscv64.cc
@@ -325,7 +325,7 @@ void EmitWordLoadPoisoningIfNeeded(CodeGenerator* codegen,
     __ bin_instr(i.TempRegister(1), i.OutputRegister(0),                       \
                  Operand(i.InputRegister(2)));                                 \
     __ store_conditional(i.TempRegister(1), MemOperand(i.TempRegister(0), 0)); \
-    __ BranchShort(&binop, eq, i.TempRegister(1), Operand(zero_reg));          \
+    __ BranchShort(&binop, ne, i.TempRegister(1), Operand(zero_reg));          \
     __ sync();                                                                 \
   } while (0)
 
@@ -353,7 +353,7 @@ void EmitWordLoadPoisoningIfNeeded(CodeGenerator* codegen,
     __ InsertBits(i.TempRegister(1), i.TempRegister(2), i.TempRegister(3),     \
                   size);                                                       \
     __ store_conditional(i.TempRegister(1), MemOperand(i.TempRegister(0), 0)); \
-    __ BranchShort(&binop, eq, i.TempRegister(1), Operand(zero_reg));          \
+    __ BranchShort(&binop, ne, i.TempRegister(1), Operand(zero_reg));          \
     __ sync();                                                                 \
   } while (0)
 
@@ -366,7 +366,7 @@ void EmitWordLoadPoisoningIfNeeded(CodeGenerator* codegen,
     __ load_linked(i.OutputRegister(0), MemOperand(i.TempRegister(0), 0));     \
     __ Move(i.TempRegister(1), i.InputRegister(2));                            \
     __ store_conditional(i.TempRegister(1), MemOperand(i.TempRegister(0), 0)); \
-    __ BranchShort(&exchange, eq, i.TempRegister(1), Operand(zero_reg));       \
+    __ BranchShort(&exchange, ne, i.TempRegister(1), Operand(zero_reg));       \
     __ sync();                                                                 \
   } while (0)
 
@@ -392,7 +392,7 @@ void EmitWordLoadPoisoningIfNeeded(CodeGenerator* codegen,
     __ InsertBits(i.TempRegister(2), i.InputRegister(2), i.TempRegister(1),    \
                   size);                                                       \
     __ store_conditional(i.TempRegister(2), MemOperand(i.TempRegister(0), 0)); \
-    __ BranchShort(&exchange, eq, i.TempRegister(2), Operand(zero_reg));       \
+    __ BranchShort(&exchange, ne, i.TempRegister(2), Operand(zero_reg));       \
     __ sync();                                                                 \
   } while (0)
 
@@ -409,7 +409,7 @@ void EmitWordLoadPoisoningIfNeeded(CodeGenerator* codegen,
                    Operand(i.OutputRegister(0)));                              \
     __ Move(i.TempRegister(2), i.InputRegister(3));                            \
     __ store_conditional(i.TempRegister(2), MemOperand(i.TempRegister(0), 0)); \
-    __ BranchShort(&compareExchange, eq, i.TempRegister(2),                    \
+    __ BranchShort(&compareExchange, ne, i.TempRegister(2),                    \
                    Operand(zero_reg));                                         \
     __ bind(&exit);                                                            \
     __ sync();                                                                 \
@@ -442,7 +442,7 @@ void EmitWordLoadPoisoningIfNeeded(CodeGenerator* codegen,
     __ InsertBits(i.TempRegister(2), i.InputRegister(3), i.TempRegister(1),    \
                   size);                                                       \
     __ store_conditional(i.TempRegister(2), MemOperand(i.TempRegister(0), 0)); \
-    __ BranchShort(&compareExchange, eq, i.TempRegister(2),                    \
+    __ BranchShort(&compareExchange, ne, i.TempRegister(2),                    \
                    Operand(zero_reg));                                         \
     __ bind(&exit);                                                            \
     __ sync();                                                                 \

--- a/src/execution/riscv64/simulator-riscv64.cc
+++ b/src/execution/riscv64/simulator-riscv64.cc
@@ -2095,9 +2095,9 @@ void Simulator::DecodeRVRAType() {
         local_monitor_.NotifyStore();
         GlobalMonitor::Get()->NotifyStore_Locked(&global_monitor_thread_);
         WriteMem<int32_t>(rs1(), (int32_t)rs2(), instr_.instr());
-        set_rd(1, false);
-      } else {
         set_rd(0, false);
+      } else {
+        set_rd(1, false);
       }
       break;
     }
@@ -2176,9 +2176,9 @@ void Simulator::DecodeRVRAType() {
               addr, &global_monitor_thread_))) {
         GlobalMonitor::Get()->NotifyStore_Locked(&global_monitor_thread_);
         WriteMem<int64_t>(rs1(), rs2(), instr_.instr());
-        set_rd(1, false);
-      } else {
         set_rd(0, false);
+      } else {
+        set_rd(1, false);
       }
       break;
     }


### PR DESCRIPTION
Fix #75:If the SC.[W] succeeds, the instruction writes the word in rs2 to memory, and
it writes zero to rd. If the SC.[W] fails, the instruction does not write to memory, and it writes a
nonzero value to rd.