### PR TITLE
Remove is_intN checks for DropAndRet

### DIFF
--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -3208,8 +3208,7 @@ void TurboAssembler::BranchAndLinkLong(Label* L) {
 }
 
 void TurboAssembler::DropAndRet(int drop) {
-  DCHECK(is_int12(drop * kPointerSize));
-  addi(sp, sp, drop * kPointerSize);
+  Add64(sp, sp, drop * kPointerSize);
   Ret();
 }
 

--- a/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
+++ b/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
@@ -1230,8 +1230,6 @@ void LiftoffAssembler::PopRegisters(LiftoffRegList regs) {
 }
 
 void LiftoffAssembler::DropStackSlotsAndRet(uint32_t num_stack_slots) {
-  DCHECK_LT(num_stack_slots,
-            (1 << 16) / kSystemPointerSize);  // 16 bit immediate
   TurboAssembler::DropAndRet(static_cast<int>(num_stack_slots));
 }
 


### PR DESCRIPTION
Removes the is_intN checks for DropAndRet because we now use the
TurboAssembler macro Add64(...) to help deal with larger immediate
values given.

Resolves #84