### PR TITLE
Remove apt-get update from workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - name: Update and upgrade apt
-      run: sudo apt-get update && sudo apt-get upgrade -yqq
-
     - name: Install prereqs
       run: |
         DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
This seems to cause a failure sometimes and is not strictly necessary.