### PR TITLE
[CI] Change the output style to verbose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,16 +60,16 @@ jobs:
       run: (cd v8 && ninja -C out/riscv64.sim -j2)
 
     - name: cctests
-      run: (cd v8 && tools/run-tests.py --outdir=out/riscv64.sim cctest)
+      run: (cd v8 && tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim cctest)
 
     - name: unittests
-      run: (cd v8 && tools/run-tests.py --outdir=out/riscv64.sim unittests)
+      run: (cd v8 && tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim unittests)
 
     - name: wasm tests
-      run: (cd v8 && tools/run-tests.py --outdir=out/riscv64.sim wasm-api-tests)
+      run: (cd v8 && tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim wasm-api-tests)
 
     - name: mjsunit tests
-      run: (cd v8 && tools/run-tests.py --outdir=out/riscv64.sim mjsunit)
+      run: (cd v8 && tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim mjsunit)
 
     - name: misc tests
-      run: (cd v8 && tools/run-tests.py --outdir=out/riscv64.sim intl message debugger inspector mkgrokdump)
+      run: (cd v8 && tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim intl message debugger inspector mkgrokdump)


### PR DESCRIPTION
This patch changes the output style of run-tests.py from the
default 'mono' style to 'verbose' for more useful CI log.

The problem of the mono style is that we could not figure out
easily which testcase failed and what the error message was.
And redirecting the output of run-tests.py could also capture
lots of control & invisable ASCII chars, which is not useful.