### PR TITLE
When gen jal or jalr, retain some memory before pop BlockTrampolinePool.

### DIFF
--- a/src/codegen/riscv64/assembler-riscv64.cc
+++ b/src/codegen/riscv64/assembler-riscv64.cc
@@ -970,10 +970,16 @@ void Assembler::auipc(Register rd, int32_t imm20) {
 
 // Jumps
 
-void Assembler::jal(Register rd, int32_t imm21) { GenInstrJ(JAL, rd, imm21); }
+void Assembler::jal(Register rd, int32_t imm21) { 
+  BlockTrampolinePoolScope block_trampoline_pool(this);
+  GenInstrJ(JAL, rd, imm21);
+  BlockTrampolinePoolFor(1);
+}
 
 void Assembler::jalr(Register rd, Register rs1, int16_t imm12) {
+  BlockTrampolinePoolScope block_trampoline_pool(this); 
   GenInstrI(0b000, JALR, rd, rs1, imm12);
+  BlockTrampolinePoolFor(1);
 }
 
 // Branches

--- a/test/mjsunit/mjsunit.status
+++ b/test/mjsunit/mjsunit.status
@@ -832,11 +832,7 @@
 
 ['arch == riscv64 or arch == riscv', {
   'regress/wasm/regress-1032753': [SKIP], # issue 57
-  'es6/block-conflicts-sloppy': [SKIP], # issue 56
-  'es6/promises': [SKIP], # issue 56
-
   'wasm/float-constant-folding': [SKIP], # issue 53
-  'wasm/shared-memory-gc-stress': [SKIP], # issue 56
 
 
   # disable all asm/embenchen tests for now


### PR DESCRIPTION
RecordCallPosition record current pc into SafepointTable.
If pop a BlockTrampolinePool after jalr, return address in stack cant't be found in SafepointTable.
Fix #56.
Fix #129 