### PR TITLE
Use fmv_x_w and fmv_w_x to implement BitCast between F32 and I32

### DIFF
--- a/src/compiler/backend/riscv64/code-generator-riscv64.cc
+++ b/src/compiler/backend/riscv64/code-generator-riscv64.cc
@@ -1506,6 +1506,12 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     case kRiscvBitcastLD:
       __ fmv_d_x(i.OutputDoubleRegister(), i.InputRegister(0));
       break;
+    case kRiscvBitcastInt32ToFloat32:
+      __ fmv_w_x(i.OutputDoubleRegister(), i.InputRegister(0));
+      break;
+    case kRiscvBitcastFloat32ToInt32:
+      __ fmv_x_w(i.OutputRegister(), i.InputDoubleRegister(0));
+      break;
     case kRiscvFloat64ExtractLowWord32:
       __ ExtractLowWordFromF64(i.OutputRegister(), i.InputDoubleRegister(0));
       break;

--- a/src/compiler/backend/riscv64/instruction-codes-riscv64.h
+++ b/src/compiler/backend/riscv64/instruction-codes-riscv64.h
@@ -142,6 +142,8 @@ namespace compiler {
   V(RiscvUStoreDouble)                      \
   V(RiscvBitcastDL)                         \
   V(RiscvBitcastLD)                         \
+  V(RiscvBitcastInt32ToFloat32)             \
+  V(RiscvBitcastFloat32ToInt32)             \
   V(RiscvFloat64ExtractLowWord32)           \
   V(RiscvFloat64ExtractHighWord32)          \
   V(RiscvFloat64InsertLowWord32)            \

--- a/src/compiler/backend/riscv64/instruction-scheduler-riscv64.cc
+++ b/src/compiler/backend/riscv64/instruction-scheduler-riscv64.cc
@@ -24,6 +24,8 @@ int InstructionScheduler::GetTargetInstructionFlags(
     case kRiscvAssertEqual:
     case kRiscvBitcastDL:
     case kRiscvBitcastLD:
+    case kRiscvBitcastInt32ToFloat32:
+    case kRiscvBitcastFloat32ToInt32:
     case kRiscvByteSwap32:
     case kRiscvByteSwap64:
     case kRiscvCeilWD:

--- a/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
+++ b/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
@@ -1294,7 +1294,7 @@ void InstructionSelector::VisitRoundUint64ToFloat64(Node* node) {
 }
 
 void InstructionSelector::VisitBitcastFloat32ToInt32(Node* node) {
-  VisitRR(this, kRiscvFloat64ExtractLowWord32, node);
+  VisitRR(this, kRiscvBitcastFloat32ToInt32, node);
 }
 
 void InstructionSelector::VisitBitcastFloat64ToInt64(Node* node) {
@@ -1302,10 +1302,7 @@ void InstructionSelector::VisitBitcastFloat64ToInt64(Node* node) {
 }
 
 void InstructionSelector::VisitBitcastInt32ToFloat32(Node* node) {
-  RiscvOperandGenerator g(this);
-  Emit(kRiscvFloat64InsertLowWord32, g.DefineAsRegister(node),
-       ImmediateOperand(ImmediateOperand::INLINE, 0),
-       g.UseRegister(node->InputAt(0)));
+  VisitRR(this, kRiscvBitcastInt32ToFloat32, node);
 }
 
 void InstructionSelector::VisitBitcastInt64ToFloat64(Node* node) {
@@ -2750,7 +2747,7 @@ SIMD_UNOP_LIST(SIMD_VISIT_UNOP)
 
 #define SIMD_VISIT_SHIFT_OP(Name)                     \
   void InstructionSelector::Visit##Name(Node* node) { \
-    VisitSimdShift(this, kRiscv##Name, node);        \
+    VisitSimdShift(this, kRiscv##Name, node);         \
   }
 SIMD_SHIFT_OP_LIST(SIMD_VISIT_SHIFT_OP)
 #undef SIMD_VISIT_SHIFT_OP

--- a/test/cctest/cctest.status
+++ b/test/cctest/cctest.status
@@ -372,18 +372,6 @@
 ['arch == riscv  or arch == riscv64', {
   # this test is unstable, sometimes fail when running w/ other tests
   'test-cpu-profiler/CrossScriptInliningCallerLineNumbers2': [SKIP],
-
-  # BUG(113): SIMD test failed
-  'test-run-wasm-simd/RunWasm_SimdF32x4AddWithI32x4_simd_lowered': [SKIP],
-  'test-run-wasm-simd/RunWasm_SimdF32x4AddWithI32x4_turbofan': [SKIP],
-  'test-run-wasm-simd/RunWasm_SimdF32x4ExtractWithI32x4_simd_lowered': [SKIP],
-  'test-run-wasm-simd/RunWasm_SimdF32x4ExtractWithI32x4_turbofan': [SKIP],
-  'test-run-wasm-simd/RunWasm_SimdF32x4GetGlobal_simd_lowered': [SKIP],
-  'test-run-wasm-simd/RunWasm_SimdF32x4GetGlobal_turbofan': [SKIP],
-  'test-run-wasm-simd-scalar-lowering/RunWasm_I8x16ToF32x4_simd_lowered': [SKIP],
-  'test-run-wasm-simd/RunWasm_SimdF32x4AddWithI32x4_liftoff': [SKIP],
-  'test-run-wasm-simd/RunWasm_SimdF32x4GetGlobal_liftoff': [SKIP],
-  'test-run-wasm-simd/RunWasm_SimdF32x4ExtractWithI32x4_liftoff': [SKIP],
 }],
 
 ##############################################################################

--- a/test/debugger/debugger.status
+++ b/test/debugger/debugger.status
@@ -127,11 +127,6 @@
 }],  # 'arch == s390 or arch == s390x'
 
 ##############################################################################
-['arch == riscv64 or arch == riscv', {
-  'debug/side-effect/debug-evaluate-no-side-effect-builtins': [SKIP], # issue 152
-}],  # 'arch == riscv64 or arch == riscv'
-
-##############################################################################
 ['lite_mode or variant == jitless', {
   # TODO(v8:7777): Re-enable once wasm is supported in jitless mode.
   'debug/wasm/*': [SKIP],

--- a/test/mjsunit/mjsunit.status
+++ b/test/mjsunit/mjsunit.status
@@ -867,9 +867,6 @@
   'wasm/float-constant-folding': [SKIP], # issue 53
   'regress/regress-1067270': [SKIP], # issue 142
   'wasm/stack': [SKIP], # issue 141
-  'compiler/dataview-detached': [SKIP], # issue 149
-  'compiler/int64': [SKIP], # issue 150
-  'tools/foozzie': [SKIP], # issue 163
 
   # disable all asm/embenchen tests for now
   'asm/embenchen/box2d': [SKIP],


### PR DESCRIPTION
The bug is due to using `fmv_d_w` to implement `BitCastI32ToFloat32`. This causes problems because on RISCV,64 32-bit float needs to be Nan-boxed when in FPR (64-bit), and only `fmv_x_w` does nan-boxing when moving from GPR to FPR.
