### PR TITLE
Refactor TurboAssembler move APIs

### DIFF
--- a/src/builtins/riscv64/builtins-riscv64.cc
+++ b/src/builtins/riscv64/builtins-riscv64.cc
@@ -559,7 +559,7 @@ void Generate_JSEntryVariant(MacroAssembler* masm, StackFrame::Type type,
     // Save callee-saved FPU registers.
     __ MultiPushFPU(kCalleeSavedFPU);
     // Set up the reserved register for 0.0.
-    __ Move(kDoubleRegZero, 0.0);
+    __ LoadFPRImmediate(kDoubleRegZero, 0.0);
 
     // Initialize the root register.
     // C calling convention. The first argument is passed in a0.

--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -1823,10 +1823,12 @@ void TurboAssembler::RoundHelper(FPURegister dst, FPURegister src,
   // if src is NaN/+-Infinity/+-Zero or if the exponent is larger than # of bits
   // in mantissa, the result is the same as src, so move src to dest  (to avoid
   // generating another branch)
-  if (std::is_same<F, double>::value) {
-    Move_d(dst, src);
-  } else {
-    Move_s(dst, src);
+  if (dst != src) {
+    if (std::is_same<F, double>::value) {
+      fmv_d(dst, src);
+    } else {
+      fmv_s(dst, src);
+    }
   }
 
   // If real exponent (i.e., t6 - kFloatExponentBias) is greater than
@@ -2059,24 +2061,10 @@ void TurboAssembler::InsertLowWordF64(FPURegister dst, Register src_low) {
   fmv_d_x(dst, scratch);
 }
 
-void TurboAssembler::Move(FPURegister dst, Register src_low,
-                          Register src_high) {
-  UseScratchRegisterScope temps(this);
-  Register scratch = temps.Acquire();
-  BlockTrampolinePoolScope block_trampoline_pool(this);
-
-  DCHECK(src_high != t5 && src_high != scratch);
-  slli(scratch, src_low, 32);
-  slli(t5, src_high, 32);
-  srli(scratch, scratch, 32);
-  or_(scratch, scratch, t5);
-  fmv_d_x(dst, scratch);
-}
-
-void TurboAssembler::Move(FPURegister dst, uint32_t src) {
+void TurboAssembler::LoadFPRImmediate(FPURegister dst, uint32_t src) {
   // Handle special values first.
   if (src == bit_cast<uint32_t>(0.0f) && has_single_zero_reg_set_) {
-    Move_s(dst, kDoubleRegZero);
+    if (dst != kDoubleRegZero) fmv_s(dst, kDoubleRegZero);
   } else if (src == bit_cast<uint32_t>(-0.0f) && has_single_zero_reg_set_) {
     Neg_s(dst, kDoubleRegZero);
   } else {
@@ -2094,10 +2082,10 @@ void TurboAssembler::Move(FPURegister dst, uint32_t src) {
   }
 }
 
-void TurboAssembler::Move(FPURegister dst, uint64_t src) {
+void TurboAssembler::LoadFPRImmediate(FPURegister dst, uint64_t src) {
   // Handle special values first.
   if (src == bit_cast<uint64_t>(0.0) && has_double_zero_reg_set_) {
-    Move_d(dst, kDoubleRegZero);
+    if (dst != kDoubleRegZero) fmv_d(dst, kDoubleRegZero);
   } else if (src == bit_cast<uint64_t>(-0.0) && has_double_zero_reg_set_) {
     Neg_d(dst, kDoubleRegZero);
   } else {
@@ -4067,11 +4055,11 @@ void TurboAssembler::FloatMinMaxHelper(FPURegister dst, FPURegister src1,
   DCHECK((std::is_same<F_TYPE, float>::value) ||
          (std::is_same<F_TYPE, double>::value));
 
-  if (src1 == src2) {
+  if (src1 == src2 && dst != src1) {
     if (std::is_same<float, F_TYPE>::value) {
-      Move_s(dst, src1);
+      fmv_s(dst, src1);
     } else {
-      Move_d(dst, src1);
+      fmv_d(dst, src1);
     }
     return;
   }

--- a/src/codegen/riscv64/macro-assembler-riscv64.h
+++ b/src/codegen/riscv64/macro-assembler-riscv64.h
@@ -177,9 +177,7 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   inline void li(Register rd, int64_t j, LiFlags mode = OPTIMIZE_SIZE) {
     li(rd, Operand(j), mode);
   }
-  // inline void li(Register rd, int32_t j, LiFlags mode = OPTIMIZE_SIZE) {
-  //   li(rd, Operand(static_cast<int64_t>(j)), mode);
-  // }
+
   void li(Register dst, Handle<HeapObject> value, LiFlags mode = OPTIMIZE_SIZE);
   void li(Register dst, ExternalReference value, LiFlags mode = OPTIMIZE_SIZE);
   void li(Register dst, const StringConstantBase* string,
@@ -636,9 +634,6 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   bool IsDoubleZeroRegSet() { return has_double_zero_reg_set_; }
   bool IsSingleZeroRegSet() { return has_single_zero_reg_set_; }
 
-  void mov(Register rd, Register rt) { or_(rd, rt, zero_reg); }
-
-  inline void Move(Register dst, Handle<HeapObject> handle) { li(dst, handle); }
   inline void Move(Register dst, Smi smi) { li(dst, Operand(smi)); }
 
   inline void Move(Register dst, Register src) {
@@ -647,7 +642,9 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
     }
   }
 
-  inline void Move(FPURegister dst, FPURegister src) { Move_d(dst, src); }
+  inline void Move(FPURegister dst, FPURegister src) {
+    if (dst != src) fmv_d(dst, src);
+  }
 
   inline void Move(Register dst_low, Register dst_high, FPURegister src) {
     fmv_x_d(dst_high, src);
@@ -676,20 +673,14 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   // Insert low-word from GPR (src_high) to the low-half of FPR (dst)
   void InsertLowWordF64(FPURegister dst, Register src_low);
 
-  void Move(FPURegister dst, Register src_low, Register src_high);
-
-  inline void Move_d(FPURegister dst, FPURegister src) {
-    if (dst != src) fmv_d(dst, src);
+  void LoadFPRImmediate(FPURegister dst, float imm) {
+    LoadFPRImmediate(dst, bit_cast<uint32_t>(imm));
   }
-
-  inline void Move_s(FPURegister dst, FPURegister src) {
-    if (dst != src) fmv_s(dst, src);
+  void LoadFPRImmediate(FPURegister dst, double imm) {
+    LoadFPRImmediate(dst, bit_cast<uint64_t>(imm));
   }
-
-  void Move(FPURegister dst, float imm) { Move(dst, bit_cast<uint32_t>(imm)); }
-  void Move(FPURegister dst, double imm) { Move(dst, bit_cast<uint64_t>(imm)); }
-  void Move(FPURegister dst, uint32_t src);
-  void Move(FPURegister dst, uint64_t src);
+  void LoadFPRImmediate(FPURegister dst, uint32_t src);
+  void LoadFPRImmediate(FPURegister dst, uint64_t src);
 
   // AddOverflow64 sets overflow register to a negative value if
   // overflow occured, otherwise it is zero or positive

--- a/src/compiler/backend/riscv64/code-generator-riscv64.cc
+++ b/src/compiler/backend/riscv64/code-generator-riscv64.cc
@@ -1185,7 +1185,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
 
       if ((left == kDoubleRegZero || right == kDoubleRegZero) &&
           !__ IsSingleZeroRegSet()) {
-        __ Move(kDoubleRegZero, 0.0f);
+        __ LoadFPRImmediate(kDoubleRegZero, 0.0f);
       }
       // compare result set to kScratchReg
       __ CompareF32(kScratchReg, cc, left, right);
@@ -1247,7 +1247,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
           FlagsConditionToConditionCmpFPU(&predicate, instr->flags_condition());
       if ((left == kDoubleRegZero || right == kDoubleRegZero) &&
           !__ IsDoubleZeroRegSet()) {
-        __ Move(kDoubleRegZero, 0.0);
+        __ LoadFPRImmediate(kDoubleRegZero, 0.0);
       }
       // compare result set to kScratchReg
       __ CompareF64(kScratchReg, cc, left, right);
@@ -1608,7 +1608,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       MemOperand operand = i.MemoryOperand(&index);
       FPURegister ft = i.InputOrZeroSingleRegister(index);
       if (ft == kDoubleRegZero && !__ IsSingleZeroRegSet()) {
-        __ Move(kDoubleRegZero, 0.0f);
+        __ LoadFPRImmediate(kDoubleRegZero, 0.0f);
       }
       __ StoreFloat(ft, operand);
       break;
@@ -1618,7 +1618,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       MemOperand operand = i.MemoryOperand(&index);
       FPURegister ft = i.InputOrZeroSingleRegister(index);
       if (ft == kDoubleRegZero && !__ IsSingleZeroRegSet()) {
-        __ Move(kDoubleRegZero, 0.0f);
+        __ LoadFPRImmediate(kDoubleRegZero, 0.0f);
       }
       __ UStoreFloat(ft, operand, kScratchReg);
       break;
@@ -1632,7 +1632,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     case kRiscvStoreDouble: {
       FPURegister ft = i.InputOrZeroDoubleRegister(2);
       if (ft == kDoubleRegZero && !__ IsDoubleZeroRegSet()) {
-        __ Move(kDoubleRegZero, 0.0);
+        __ LoadFPRImmediate(kDoubleRegZero, 0.0);
       }
       __ StoreDouble(ft, i.MemoryOperand());
       break;
@@ -1640,7 +1640,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     case kRiscvUStoreDouble: {
       FPURegister ft = i.InputOrZeroDoubleRegister(2);
       if (ft == kDoubleRegZero && !__ IsDoubleZeroRegSet()) {
-        __ Move(kDoubleRegZero, 0.0);
+        __ LoadFPRImmediate(kDoubleRegZero, 0.0);
       }
       __ UStoreDouble(ft, i.MemoryOperand(), kScratchReg);
       break;
@@ -2250,11 +2250,11 @@ void CodeGenerator::AssembleArchBoolean(Instruction* instr,
     if ((instr->arch_opcode() == kRiscvCmpD) &&
         (left == kDoubleRegZero || right == kDoubleRegZero) &&
         !__ IsDoubleZeroRegSet()) {
-      __ Move(kDoubleRegZero, 0.0);
+      __ LoadFPRImmediate(kDoubleRegZero, 0.0);
     } else if ((instr->arch_opcode() == kRiscvCmpS) &&
                (left == kDoubleRegZero || right == kDoubleRegZero) &&
                !__ IsSingleZeroRegSet()) {
-      __ Move(kDoubleRegZero, 0.0f);
+      __ LoadFPRImmediate(kDoubleRegZero, 0.0f);
     }
     bool predicate;
     FlagsConditionToConditionCmpFPU(&predicate, condition);
@@ -2577,14 +2577,14 @@ void CodeGenerator::AssembleMove(InstructionOperand* source,
       } else {
         DCHECK(destination->IsFPRegister());
         FloatRegister dst = g.ToSingleRegister(destination);
-        __ Move(dst, src.ToFloat32());
+        __ LoadFPRImmediate(dst, src.ToFloat32());
       }
     } else {
       DCHECK_EQ(Constant::kFloat64, src.type());
       DoubleRegister dst = destination->IsFPRegister()
                                ? g.ToDoubleRegister(destination)
                                : kScratchDoubleReg;
-      __ Move(dst, src.ToFloat64().value());
+      __ LoadFPRImmediate(dst, src.ToFloat64().value());
       if (destination->IsFPStackSlot()) {
         __ StoreDouble(dst, g.ToMemOperand(destination));
       }

--- a/src/debug/riscv64/debug-riscv64.cc
+++ b/src/debug/riscv64/debug-riscv64.cc
@@ -4,9 +4,8 @@
 
 #if V8_TARGET_ARCH_RISCV64
 
-#include "src/debug/debug.h"
-
 #include "src/codegen/macro-assembler.h"
+#include "src/debug/debug.h"
 #include "src/debug/liveedit.h"
 #include "src/execution/frames-inl.h"
 
@@ -32,7 +31,7 @@ void DebugCodegen::GenerateFrameDropperTrampoline(MacroAssembler* masm) {
   // - Look up current function on the frame.
   // - Leave the frame.
   // - Restart the frame by calling the function.
-  __ mov(fp, a1);
+  __ mv(fp, a1);
   __ Ld(a1, MemOperand(fp, StandardFrameConstants::kFunctionOffset));
 
   // Pop return address and frame.
@@ -41,7 +40,7 @@ void DebugCodegen::GenerateFrameDropperTrampoline(MacroAssembler* masm) {
   __ Ld(a0, FieldMemOperand(a1, JSFunction::kSharedFunctionInfoOffset));
   __ Lhu(a0,
          FieldMemOperand(a0, SharedFunctionInfo::kFormalParameterCountOffset));
-  __ mov(a2, a0);
+  __ mv(a2, a0);
 
   __ InvokeFunction(a1, a2, a0, JUMP_FUNCTION);
 }

--- a/src/deoptimizer/riscv64/deoptimizer-riscv64.cc
+++ b/src/deoptimizer/riscv64/deoptimizer-riscv64.cc
@@ -59,12 +59,12 @@ void Deoptimizer::GenerateDeoptimizationEntries(MacroAssembler* masm,
       (kNumberOfRegisters * kPointerSize) + kDoubleRegsSize;
 
   // Get the bailout is passed as kRootRegister by the caller.
-  __ mov(a2, kRootRegister);
+  __ mv(a2, kRootRegister);
 
   // Get the address of the location in the code object (a3) (return
   // address for lazy deoptimization) and compute the fp-to-sp delta in
   // register a4.
-  __ mov(a3, ra);
+  __ mv(a3, ra);
   __ Add64(a4, sp, Operand(kSavedRegistersAreaSize));
 
   __ Sub64(a4, fp, a4);
@@ -72,7 +72,7 @@ void Deoptimizer::GenerateDeoptimizationEntries(MacroAssembler* masm,
   // Allocate a new deoptimizer object.
   __ PrepareCallCFunction(6, a5);
   // Pass six arguments, according to n64 ABI.
-  __ mov(a0, zero_reg);
+  __ mv(a0, zero_reg);
   Label context_check;
   __ Ld(a1, MemOperand(fp, CommonFrameConstants::kContextOrFrameTypeOffset));
   __ JumpIfSmi(a1, &context_check);
@@ -196,7 +196,7 @@ void Deoptimizer::GenerateDeoptimizationEntries(MacroAssembler* masm,
   // but it's safer to check for this.
   DCHECK(!(t3.bit() & restored_regs));
   // Restore the registers from the last output frame.
-  __ mov(t3, a2);
+  __ mv(t3, a2);
   for (int i = kNumberOfRegisters - 1; i >= 0; i--) {
     int offset = (i * kPointerSize) + FrameDescription::registers_offset();
     if ((restored_regs & (1 << i)) != 0) {

--- a/src/regexp/riscv64/regexp-macro-assembler-riscv64.cc
+++ b/src/regexp/riscv64/regexp-macro-assembler-riscv64.cc
@@ -317,9 +317,9 @@ void RegExpMacroAssemblerRISCV::CheckNotBackReferenceIgnoreCase(
     // Address of start of capture.
     __ Add64(a0, a0, Operand(end_of_input_address()));
     // Length of capture.
-    __ mov(a2, a1);
+    __ mv(a2, a1);
     // Save length in callee-save register for use on return.
-    __ mov(s3, a1);
+    __ mv(s3, a1);
     // Address of current input position.
     __ Add64(a1, current_input_offset(), Operand(end_of_input_address()));
     if (read_backward) {
@@ -644,7 +644,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
              Operand(NumRegs(argument_registers) * kPointerSize));
 
     STATIC_ASSERT(kSuccessfulCaptures == kInputString - kSystemPointerSize);
-    __ mov(a0, zero_reg);
+    __ mv(a0, zero_reg);
     __ push(a0);  // Make room for success counter and initialize it to 0.
     STATIC_ASSERT(kStringStartMinusOne ==
                   kSuccessfulCaptures - kSystemPointerSize);
@@ -763,7 +763,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
           __ Ld(a3, register_location(i + 1));
           if (i == 0 && global_with_zero_length_check()) {
             // Keep capture start in a4 for the zero-length check later.
-            __ mov(t4, a2);
+            __ mv(t4, a2);
           }
           if (mode_ == UC16) {
             __ srai(a2, a2, 1);
@@ -834,7 +834,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
 
     __ bind(&return_a0);
     // Skip sp past regexp registers and local variables..
-    __ mov(sp, frame_pointer());
+    __ mv(sp, frame_pointer());
 
     // Restore registers fp..s11 and return (restoring ra to pc).
     __ MultiPop(registers_to_retain | ra.bit());
@@ -881,7 +881,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
       // Call GrowStack(backtrack_stackpointer(), &stack_base)
       static const int num_arguments = 3;
       __ PrepareCallCFunction(num_arguments, a0);
-      __ mov(a0, backtrack_stackpointer());
+      __ mv(a0, backtrack_stackpointer());
       __ Add64(a1, frame_pointer(), Operand(kStackHighEnd));
       __ li(a2, Operand(ExternalReference::isolate_address(masm_->isolate())));
       ExternalReference grow_stack =
@@ -893,7 +893,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
       // must exit with a stack-overflow exception.
       __ Branch(&exit_with_exception, eq, a0, Operand(zero_reg));
       // Otherwise use return value as new stack pointer.
-      __ mov(backtrack_stackpointer(), a0);
+      __ mv(backtrack_stackpointer(), a0);
       // Restore saved registers and continue.
       __ li(code_pointer(), Operand(masm_->CodeObject()), CONSTANT_SIZE);
       __ Ld(end_of_input_address(), MemOperand(frame_pointer(), kInputEnd));
@@ -1063,13 +1063,13 @@ void RegExpMacroAssemblerRISCV::CallCheckStackGuardState(Register scratch) {
   int stack_alignment = base::OS::ActivationFrameAlignment();
 
   // Align the stack pointer and save the original sp value on the stack.
-  __ mov(scratch, sp);
+  __ mv(scratch, sp);
   __ Sub64(sp, sp, Operand(kPointerSize));
   DCHECK(base::bits::IsPowerOfTwo(stack_alignment));
   __ And(sp, sp, Operand(-stack_alignment));
   __ Sd(scratch, MemOperand(sp));
 
-  __ mov(a2, frame_pointer());
+  __ mv(a2, frame_pointer());
   // Code of self.
   __ li(a1, Operand(masm_->CodeObject()), CONSTANT_SIZE);
 
@@ -1088,7 +1088,7 @@ void RegExpMacroAssemblerRISCV::CallCheckStackGuardState(Register scratch) {
   // [sp + 0] - first word reserved for return value.
 
   // a0 will point to the return address, placed by DirectCEntry.
-  __ mov(a0, sp);
+  __ mv(a0, sp);
 
   ExternalReference stack_guard_check =
       ExternalReference::re_check_stack_guard_state(masm_->isolate());

--- a/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
+++ b/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
@@ -307,10 +307,12 @@ void LiftoffAssembler::LoadConstant(LiftoffRegister reg, WasmValue value,
       TurboAssembler::li(reg.gp(), Operand(value.to_i64(), rmode));
       break;
     case ValueType::kF32:
-      TurboAssembler::Move(reg.fp(), value.to_f32_boxed().get_bits());
+      TurboAssembler::LoadFPRImmediate(reg.fp(),
+                                       value.to_f32_boxed().get_bits());
       break;
     case ValueType::kF64:
-      TurboAssembler::Move(reg.fp(), value.to_f64_boxed().get_bits());
+      TurboAssembler::LoadFPRImmediate(reg.fp(),
+                                       value.to_f64_boxed().get_bits());
       break;
     default:
       UNREACHABLE();
@@ -2242,7 +2244,7 @@ void LiftoffAssembler::CallC(const wasm::FunctionSig* sig,
   // Pass a pointer to the buffer with the arguments to the C function.
   // On RISC-V, the first argument is passed in {a0}.
   constexpr Register kFirstArgReg = a0;
-  mov(kFirstArgReg, sp);
+  mv(kFirstArgReg, sp);
 
   // Now call the C function.
   constexpr int kNumCCallArgs = 1;

--- a/test/cctest/test-macro-assembler-riscv64.cc
+++ b/test/cctest/test-macro-assembler-riscv64.cc
@@ -120,7 +120,7 @@ TEST(LoadAddress) {
   MacroAssembler assembler(isolate, v8::internal::CodeObjectRequired::kYes);
   MacroAssembler* masm = &assembler;
   Label to_jump, skip;
-  __ mov(a4, a0);
+  __ mv(a4, a0);
 
   __ Branch(&skip);
   __ bind(&to_jump);
@@ -144,7 +144,8 @@ TEST(LoadAddress) {
 
   CodeDesc desc;
   masm->GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
 
   auto f = GeneratedCode<FV>::FromCode(*code);
   (void)f.Call(0, 0, 0, 0, 0);
@@ -198,7 +199,8 @@ TEST(jump_tables4) {
 
   CodeDesc desc;
   masm->GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
 #ifdef OBJECT_PRINT
   code->Print(std::cout);
 #endif
@@ -285,7 +287,8 @@ TEST(jump_tables6) {
 
   CodeDesc desc;
   masm->GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
 #ifdef OBJECT_PRINT
   code->Print(std::cout);
 #endif
@@ -309,7 +312,8 @@ static uint64_t run_CalcScaledAddress(uint64_t rt, uint64_t rs, int8_t sa) {
 
   CodeDesc desc;
   assembler.GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
 
   auto f = GeneratedCode<FV>::FromCode(*code);
 
@@ -464,7 +468,8 @@ RET_TYPE run_Cvt(IN_TYPE x, Func GenerateConvertInstructionFunc) {
 
   CodeDesc desc;
   assm.GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
 
   // deal w/ passing floating-point parameters to f.Call
   using IIN_TYPE =
@@ -613,7 +618,7 @@ TEST(OverflowInstructions) {
       __ AddOverflow64(t2, t0, Operand(t1), a1);
       __ Sd(t2, MemOperand(a0, offsetof(T, output_add)));
       __ Sd(a1, MemOperand(a0, offsetof(T, overflow_add)));
-      __ mov(a1, zero_reg);
+      __ mv(a1, zero_reg);
       __ AddOverflow64(t0, t0, Operand(t1), a1);
       __ Sd(t0, MemOperand(a0, offsetof(T, output_add2)));
       __ Sd(a1, MemOperand(a0, offsetof(T, overflow_add2)));
@@ -624,7 +629,7 @@ TEST(OverflowInstructions) {
       __ SubOverflow64(t2, t0, Operand(t1), a1);
       __ Sd(t2, MemOperand(a0, offsetof(T, output_sub)));
       __ Sd(a1, MemOperand(a0, offsetof(T, overflow_sub)));
-      __ mov(a1, zero_reg);
+      __ mv(a1, zero_reg);
       __ SubOverflow64(t0, t0, Operand(t1), a1);
       __ Sd(t0, MemOperand(a0, offsetof(T, output_sub2)));
       __ Sd(a1, MemOperand(a0, offsetof(T, overflow_sub2)));
@@ -636,7 +641,7 @@ TEST(OverflowInstructions) {
       __ MulOverflow32(t2, t0, Operand(t1), a1);
       __ Sd(t2, MemOperand(a0, offsetof(T, output_mul)));
       __ Sd(a1, MemOperand(a0, offsetof(T, overflow_mul)));
-      __ mov(a1, zero_reg);
+      __ mv(a1, zero_reg);
       __ MulOverflow32(t0, t0, Operand(t1), a1);
       __ Sd(t0, MemOperand(a0, offsetof(T, output_mul2)));
       __ Sd(a1, MemOperand(a0, offsetof(T, overflow_mul2)));
@@ -746,7 +751,8 @@ TEST(min_max_nan) {
 
   CodeDesc desc;
   masm->GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
   auto f = GeneratedCode<F3>::FromCode(*code);
   for (int i = 0; i < kTableLength; i++) {
     test.a = inputsa[i];
@@ -777,7 +783,8 @@ bool run_Unaligned(char* memory_buffer, int32_t in_offset, int32_t out_offset,
 
   CodeDesc desc;
   assm.GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
   auto f = GeneratedCode<int32_t(char*)>::FromCode(*code);
 
   MemCopy(memory_buffer + in_offset, &value, sizeof(IN_TYPE));
@@ -832,7 +839,7 @@ TEST(Ulh) {
         // test when loaded value overwrites base-register of load address
         auto fn_2 = [](MacroAssembler* masm, int32_t in_offset,
                        int32_t out_offset) {
-          __ mov(t0, a0);
+          __ mv(t0, a0);
           __ Ulh(a0, MemOperand(a0, in_offset));
           __ Ush(a0, MemOperand(t0, out_offset));
         };
@@ -842,7 +849,7 @@ TEST(Ulh) {
         // test when loaded value overwrites base-register of load address
         auto fn_3 = [](MacroAssembler* masm, int32_t in_offset,
                        int32_t out_offset) {
-          __ mov(t0, a0);
+          __ mv(t0, a0);
           __ Ulhu(a0, MemOperand(a0, in_offset));
           __ Ush(a0, MemOperand(t0, out_offset));
         };
@@ -938,7 +945,7 @@ TEST(Ulw) {
         // test when loaded value overwrites base-register of load address
         auto fn_2 = [](MacroAssembler* masm, int32_t in_offset,
                        int32_t out_offset) {
-          __ mov(t0, a0);
+          __ mv(t0, a0);
           __ Ulw(a0, MemOperand(a0, in_offset));
           __ Usw(a0, MemOperand(t0, out_offset));
         };
@@ -957,7 +964,7 @@ TEST(Ulw) {
         // test when loaded value overwrites base-register of load address
         auto fn_4 = [](MacroAssembler* masm, int32_t in_offset,
                        int32_t out_offset) {
-          __ mov(t0, a0);
+          __ mv(t0, a0);
           __ Ulwu(a0, MemOperand(a0, in_offset));
           __ Usw(a0, MemOperand(t0, out_offset));
         };
@@ -1046,7 +1053,7 @@ TEST(Uld) {
         // test when loaded value overwrites base-register of load address
         auto fn_2 = [](MacroAssembler* masm, int32_t in_offset,
                        int32_t out_offset) {
-          __ mov(t0, a0);
+          __ mv(t0, a0);
           __ Uld(a0, MemOperand(a0, in_offset));
           __ Usd(a0, MemOperand(t0, out_offset));
         };
@@ -1144,7 +1151,8 @@ bool run_Sltu(uint64_t rs, uint64_t rd, Func GenerateSltuInstructionFunc) {
 
   CodeDesc desc;
   assm.GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
 
   auto f = GeneratedCode<F_CVT>::FromCode(*code);
   int64_t res = reinterpret_cast<int64_t>(f.Call(rs, rd));
@@ -1434,7 +1442,8 @@ int32_t run_CompareF(IN_TYPE x1, IN_TYPE x2, bool expected_res,
 
   CodeDesc desc;
   assm.GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
 
   // deal w/ passing floating-point parameters to f.Call
   using IIN_TYPE =
@@ -1648,7 +1657,8 @@ TEST(Dpopcnt) {
 
   CodeDesc desc;
   masm->GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
 
   auto f = GeneratedCode<FV>::FromCode(*code);
   (void)f.Call(reinterpret_cast<int64_t>(result), 0, 0, 0, 0);
@@ -1706,7 +1716,8 @@ TEST(Popcnt) {
 
   CodeDesc desc;
   masm->GetCode(isolate, &desc);
-  Handle<Code> code = Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
 
   auto f = GeneratedCode<FV>::FromCode(*code);
   (void)f.Call(reinterpret_cast<int64_t>(result), 0, 0, 0, 0);


### PR DESCRIPTION
Refactoring and cleanup, no logical changes.

- Move is a heavily overloaded API that represents both move between
registers and move between immediate value and registers. For the
latter, rename it to LoadFPRImmediate().
- Replace mov() by Assembler::mv()
- Remove Move_s and Move_d

Close #126