### PR TITLE
enable build for riscv64

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -4303,6 +4303,8 @@ v8_source_set("v8_cppgc_shared") {
       sources += [ "src/heap/base/asm/mips/push_registers_asm.cc" ]
     } else if (current_cpu == "mips64el") {
       sources += [ "src/heap/base/asm/mips64/push_registers_asm.cc" ]
+    } else if (current_cpu == "riscv64") {
+      sources += [ "src/heap/base/asm/riscv64/push_registers_asm.cc" ]
     }
   } else if (is_win) {
     if (current_cpu == "x64") {
@@ -4939,6 +4941,10 @@ if (want_v8_shell) {
 v8_executable("cppgc_for_v8_embedders") {
   sources = [ "samples/cppgc/cppgc-for-v8-embedders.cc" ]
 
+  if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv") {
+    libs = [ "atomic" ]
+  }
+
   configs = [
     # Note: don't use :internal_config here because this target will get
     # the :external_config applied to it by virtue of depending on :cppgc, and
@@ -4955,6 +4961,10 @@ v8_executable("cppgc_for_v8_embedders") {
 
 v8_executable("cppgc_standalone") {
   sources = [ "samples/cppgc/cppgc-standalone.cc" ]
+
+  if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv") {
+    libs = [ "atomic" ]
+  }
 
   configs = [
     # Note: don't use :internal_config here because this target will get

--- a/src/heap/base/asm/riscv64/push_registers_asm.cc
+++ b/src/heap/base/asm/riscv64/push_registers_asm.cc
@@ -1,0 +1,47 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Push all callee-saved registers to get them on the stack for conservative
+// stack scanning.
+//
+// See asm/x64/push_registers_clang.cc for why the function is not generated
+// using clang.
+//
+// Do not depend on V8_TARGET_OS_* defines as some embedders may override the
+// GN toolchain (e.g. ChromeOS) and not provide them.
+asm(
+    ".global PushAllRegistersAndIterateStack             \n"
+    ".type PushAllRegistersAndIterateStack, %function    \n"
+    ".hidden PushAllRegistersAndIterateStack             \n"
+    "PushAllRegistersAndIterateStack:                    \n"
+    // Push all callee-saved registers and save return address.
+    "  addi sp, sp, -96                                  \n"
+    "  sd ra, 88(sp)                                     \n"
+    "  sd s8, 80(sp)                                     \n"
+    "  sd sp, 72(sp)                                     \n"
+    "  sd gp, 64(sp)                                     \n"
+    "  sd s7, 56(sp)                                     \n"
+    "  sd s6, 48(sp)                                     \n"
+    "  sd s5, 40(sp)                                     \n"
+    "  sd s4, 32(sp)                                     \n"
+    "  sd s3, 24(sp)                                     \n"
+    "  sd s2, 16(sp)                                     \n"
+    "  sd s1,  8(sp)                                     \n"
+    "  sd s0,  0(sp)                                     \n"
+    // Maintain frame pointer.
+    "  mv s8, sp                                         \n"
+    // Pass 1st parameter (a0) unchanged (Stack*).
+    // Pass 2nd parameter (a1) unchanged (StackVisitor*).
+    // Save 3rd parameter (a2; IterateStackCallback).
+    "  mv a3, a2                                         \n"
+    "  mv a2, sp                                         \n"
+    // Call the callback.
+    "  jalr a3                                           \n"
+    // Load return address.
+    "  ld ra, 88(sp)                                     \n"
+    // Restore frame pointer.
+    "  ld s8, 80(sp)                                     \n"
+    "  addi sp, sp, 96                                   \n"
+    "  jr ra                                             \n");
+

--- a/test/unittests/BUILD.gn
+++ b/test/unittests/BUILD.gn
@@ -25,6 +25,10 @@ if (is_fuchsia) {
 # target for simplicity.
 v8_executable("cppgc_unittests") {
   testonly = true
+  
+  if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv") {
+    libs = [ "atomic" ]
+  }
 
   configs = [
     "../..:external_config",


### PR DESCRIPTION
1. Add lib atomic to BUILD.gn to build torque-language-server and cppgc_* which is new executable file from upstream.
2. The cppgc_* need push_registers_asm.cc under dir src/heap/base/asm/riscv64.

Now, we can build all file with command ninja -C out/riscv64.native.debug/.
