### PR TITLE
When emit a instr, run CheckTrampolinePoolQuick().

### DIFF
--- a/src/codegen/riscv64/assembler-riscv64-inl.h
+++ b/src/codegen/riscv64/assembler-riscv64-inl.h
@@ -229,6 +229,7 @@ void Assembler::EmitHelper(T x) {
   disassembleInstr((int)x);
   *reinterpret_cast<T*>(pc_) = x;
   pc_ += sizeof(x);
+  CheckTrampolinePoolQuick();
 }
 
 void Assembler::emit(Instr x) {

--- a/test/mjsunit/mjsunit.status
+++ b/test/mjsunit/mjsunit.status
@@ -866,8 +866,6 @@
 ['arch == riscv64 or arch == riscv', {
   'wasm/float-constant-folding': [SKIP], # issue 53
   'regress/regress-1067270': [SKIP], # issue 142
-  'wasm/stack': [SKIP], # issue 141
-  'asm/poppler/poppler': [SKIP], # issue 141
 
   'wasm/memory_2gb_oob': [SKIP], # OOM: sorry, best effort max memory size test
   'wasm/memory_4gb_oob': [SKIP], # OOM: sorry, best effort max memory size test


### PR DESCRIPTION
   fix #141