### PR TITLE
Replace movz/movnz w/ optimized sequence

### DIFF
--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -2103,20 +2103,6 @@ void TurboAssembler::LoadFPRImmediate(FPURegister dst, uint64_t src) {
   }
 }
 
-void TurboAssembler::Movz(Register rd, Register rs, Register rt) {
-  Label done;
-  Branch(&done, ne, rt, Operand(zero_reg));
-  mv(rd, rs);
-  bind(&done);
-}
-
-void TurboAssembler::Movn(Register rd, Register rs, Register rt) {
-  Label done;
-  Branch(&done, eq, rt, Operand(zero_reg));
-  mv(rd, rs);
-  bind(&done);
-}
-
 void TurboAssembler::LoadZeroOnCondition(Register rd, Register rs,
                                          const Operand& rt, Condition cond) {
   BlockTrampolinePoolScope block_trampoline_pool(this);

--- a/src/codegen/riscv64/macro-assembler-riscv64.h
+++ b/src/codegen/riscv64/macro-assembler-riscv64.h
@@ -503,10 +503,6 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   void TruncateDoubleToI(Isolate* isolate, Zone* zone, Register result,
                          DoubleRegister double_input, StubCallMode stub_mode);
 
-  // Conditional move.
-  void Movz(Register rd, Register rs, Register rt);
-  void Movn(Register rd, Register rs, Register rt);
-
   void LoadZeroIfConditionNotZero(Register dest, Register condition);
   void LoadZeroIfConditionZero(Register dest, Register condition);
   void LoadZeroOnCondition(Register rd, Register rs, const Operand& rt,


### PR DESCRIPTION
Movz is a MIPS64 legacy that maps to branch and move instructions on RISCV.
- Replace consecutive uses of Movz testing the same register against
zero by a single conditional branch
- Replace a special patterns of Movz(rd, rt, rt) and Movz(rd, zero, rt) with
Seleqz and Selnez