### PR TITLE
enable fuzzer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,3 +70,6 @@ jobs:
 
     - name: misc tests
       run: (cd v8 && tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim intl message debugger inspector mkgrokdump)
+
+    - name: fuzzer tests
+      run: (cd v8 && tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim fuzzer)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,3 +42,8 @@ misc_tests:
   stage: test
   script:
     - tools/run-tests.py --outdir=out.gn/riscv64_debug intl message debugger inspector mkgrokdump
+
+fuzzer_tests:
+  stage: test
+  script:
+    - tools/run-tests.py --outdir=out.gn/riscv64_debug fuzzer

--- a/v8-riscv-tools/test-riscv.sh
+++ b/v8-riscv-tools/test-riscv.sh
@@ -9,3 +9,4 @@ $DIR/../tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim wasm-api
 $DIR/../tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim mjsunit
 $DIR/../tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim intl message debugger inspector mkgrokdump
 $DIR/../tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim wasm-spec-tests
+$DIR/../tools/run-tests.py -p verbose --report --outdir=out/riscv64.sim fuzzer


### PR DESCRIPTION
Fuzzer tests work when we switch riscv64. 

[upstream issue](https://bugs.chromium.org/p/v8/issues/detail?id=10770)

Fixed #6