### PR TITLE
Improve codegen for compare and branch

### DIFF
--- a/src/builtins/riscv64/builtins-riscv64.cc
+++ b/src/builtins/riscv64/builtins-riscv64.cc
@@ -2760,8 +2760,9 @@ void Builtins::Generate_DoubleToI(MacroAssembler* masm) {
 
   // Check for Infinity and NaNs, which should return 0.
   __ Sub32(scratch, result_reg, HeapNumber::kExponentMask);
-  __ Selnez(result_reg, result_reg,
-            scratch);  // result_reg = (scratch != 0) ? result_reg : 0
+  __ LoadZeroIfConditionZero(
+      result_reg,
+      scratch);  // result_reg = scratch == 0 ? 0 : result_reg
   __ Branch(&done, eq, scratch, Operand(zero_reg));
 
   // Express exponent as delta to (number of mantissa bits + 31).

--- a/src/codegen/riscv64/constants-riscv64.h
+++ b/src/codegen/riscv64/constants-riscv64.h
@@ -524,9 +524,12 @@ inline Condition NegateFpuCondition(Condition cc) {
 // ----- Coprocessor conditions.
 enum FPUCondition {
   kNoFPUCondition = -1,
-  EQ = 0x02,  // Equal.
+  EQ = 0x02,  // Ordered and Equal
+  NE = 0x03,  // Unordered or Not Equal
   LT = 0x04,  // Ordered and Less Than
+  GE = 0x05,  // Ordered and Greater Than or Equal
   LE = 0x06,  // Ordered and Less Than or Equal
+  GT = 0x07,  // Ordered and Greater Than
 };
 
 enum CheckForInexactConversion {

--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -1942,14 +1942,24 @@ void MacroAssembler::Msub_d(FPURegister fd, FPURegister fr, FPURegister fs,
 void TurboAssembler::CompareF32(Register rd, FPUCondition cc, FPURegister cmp1,
                                 FPURegister cmp2) {
   switch (cc) {
-    case EQ:  // Equal.
+    case EQ:
       feq_s(rd, cmp1, cmp2);
       break;
-    case LT:  // Ordered and Less Than
+    case NE:
+      feq_s(rd, cmp1, cmp2);
+      NegateBool(rd, rd);
+      break;
+    case LT:
       flt_s(rd, cmp1, cmp2);
       break;
-    case LE:  // Ordered and Less Than or Equal
+    case GE:
+      fle_s(rd, cmp2, cmp1);
+      break;
+    case LE:
       fle_s(rd, cmp1, cmp2);
+      break;
+    case GT:
+      flt_s(rd, cmp2, cmp1);
       break;
     default:
       UNREACHABLE();
@@ -1959,14 +1969,24 @@ void TurboAssembler::CompareF32(Register rd, FPUCondition cc, FPURegister cmp1,
 void TurboAssembler::CompareF64(Register rd, FPUCondition cc, FPURegister cmp1,
                                 FPURegister cmp2) {
   switch (cc) {
-    case EQ:  // Equal.
+    case EQ:
       feq_d(rd, cmp1, cmp2);
       break;
-    case LT:  // Ordered or Less Than
+    case NE:
+      feq_d(rd, cmp1, cmp2);
+      NegateBool(rd, rd);
+      break;
+    case LT:
       flt_d(rd, cmp1, cmp2);
       break;
-    case LE:  // Ordered or Less Than or Equal
+    case GE:
+      fle_d(rd, cmp2, cmp1);
+      break;
+    case LE:
       fle_d(rd, cmp1, cmp2);
+      break;
+    case GT:
+      flt_d(rd, cmp2, cmp1);
       break;
     default:
       UNREACHABLE();

--- a/src/codegen/riscv64/macro-assembler-riscv64.h
+++ b/src/codegen/riscv64/macro-assembler-riscv64.h
@@ -150,17 +150,18 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
 #undef COND_TYPED_ARGS
 #undef COND_ARGS
 
-  // Floating point branches
+  inline void NegateBool(Register rd, Register rs) { Xor(rd, rs, 1); }
+
+  // Compare float, if any operand is NaN, result is false except for NE
   void CompareF32(Register rd, FPUCondition cc, FPURegister cmp1,
                   FPURegister cmp2);
-
-  void CompareIsNanF32(Register rd, FPURegister cmp1, FPURegister cmp2);
-
+  // Compare double, if any operand is NaN, result is false except for NE
   void CompareF64(Register rd, FPUCondition cc, FPURegister cmp1,
                   FPURegister cmp2);
-
+  void CompareIsNanF32(Register rd, FPURegister cmp1, FPURegister cmp2);
   void CompareIsNanF64(Register rd, FPURegister cmp1, FPURegister cmp2);
 
+  // Floating point branches
   void BranchTrueShortF(Register rs, Label* target);
   void BranchFalseShortF(Register rs, Label* target);
 

--- a/src/codegen/riscv64/macro-assembler-riscv64.h
+++ b/src/codegen/riscv64/macro-assembler-riscv64.h
@@ -414,6 +414,8 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   DEFINE_INSTRUCTION(Sgtu)
   DEFINE_INSTRUCTION(Sge)
   DEFINE_INSTRUCTION(Sgeu)
+  DEFINE_INSTRUCTION(Seq)
+  DEFINE_INSTRUCTION(Sne)
 
   DEFINE_INSTRUCTION(Sll64)
   DEFINE_INSTRUCTION(Sra64)
@@ -424,6 +426,9 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
 
   DEFINE_INSTRUCTION(Selnez)
   DEFINE_INSTRUCTION(Seleqz)
+  DEFINE_INSTRUCTION2(Seqz)
+  DEFINE_INSTRUCTION2(Snez)
+
   DEFINE_INSTRUCTION(Ror)
   DEFINE_INSTRUCTION(Dror)
 #undef DEFINE_INSTRUCTION
@@ -503,6 +508,8 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   // Exits with 'result' holding the answer.
   void TruncateDoubleToI(Isolate* isolate, Zone* zone, Register result,
                          DoubleRegister double_input, StubCallMode stub_mode);
+
+  void CompareI(Register rd, Register rs, const Operand& rt, Condition cond);
 
   void LoadZeroIfConditionNotZero(Register dest, Register condition);
   void LoadZeroIfConditionZero(Register dest, Register condition);

--- a/src/codegen/riscv64/macro-assembler-riscv64.h
+++ b/src/codegen/riscv64/macro-assembler-riscv64.h
@@ -424,8 +424,6 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   DEFINE_INSTRUCTION(Sra32)
   DEFINE_INSTRUCTION(Srl32)
 
-  DEFINE_INSTRUCTION(Selnez)
-  DEFINE_INSTRUCTION(Seleqz)
   DEFINE_INSTRUCTION2(Seqz)
   DEFINE_INSTRUCTION2(Snez)
 
@@ -513,8 +511,6 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
 
   void LoadZeroIfConditionNotZero(Register dest, Register condition);
   void LoadZeroIfConditionZero(Register dest, Register condition);
-  void LoadZeroOnCondition(Register rd, Register rs, const Operand& rt,
-                           Condition cond);
 
   void SignExtendByte(Register rd, Register rs) {
     slli(rd, rs, 64 - 8);

--- a/src/compiler/backend/riscv64/code-generator-riscv64.cc
+++ b/src/compiler/backend/riscv64/code-generator-riscv64.cc
@@ -1016,13 +1016,13 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     case kRiscvDiv32: {
       __ Div32(i.OutputRegister(), i.InputRegister(0), i.InputOperand(1));
       // Set ouput to zero if divisor == 0
-      __ Selnez(i.OutputRegister(), i.OutputRegister(), i.InputRegister(1));
+      __ LoadZeroIfConditionZero(i.OutputRegister(), i.InputRegister(1));
       break;
     }
     case kRiscvDivU32: {
       __ Divu32(i.OutputRegister(), i.InputRegister(0), i.InputOperand(1));
       // Set ouput to zero if divisor == 0
-      __ Selnez(i.OutputRegister(), i.OutputRegister(), i.InputRegister(1));
+      __ LoadZeroIfConditionZero(i.OutputRegister(), i.InputRegister(1));
       break;
     }
     case kRiscvMod32:
@@ -1037,13 +1037,13 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     case kRiscvDiv64: {
       __ Div64(i.OutputRegister(), i.InputRegister(0), i.InputOperand(1));
       // Set ouput to zero if divisor == 0
-      __ Selnez(i.OutputRegister(), i.OutputRegister(), i.InputRegister(1));
+      __ LoadZeroIfConditionZero(i.OutputRegister(), i.InputRegister(1));
       break;
     }
     case kRiscvDivU64: {
       __ Divu64(i.OutputRegister(), i.InputRegister(0), i.InputOperand(1));
       // Set ouput to zero if divisor == 0
-      __ Selnez(i.OutputRegister(), i.OutputRegister(), i.InputRegister(1));
+      __ LoadZeroIfConditionZero(i.OutputRegister(), i.InputRegister(1));
       break;
     }
     case kRiscvMod64:
@@ -1502,7 +1502,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       // exploiting the fact that UINT32_MAX+1 is 0.
       __ Add32(kScratchReg, i.OutputRegister(), 1);
       // Set ouput to zero if result overflows (i.e., UINT32_MAX)
-      __ Selnez(i.OutputRegister(), i.OutputRegister(), kScratchReg);
+      __ LoadZeroIfConditionZero(i.OutputRegister(), kScratchReg);
       break;
     }
     case kRiscvTruncUlS: {
@@ -1991,9 +1991,9 @@ void CodeGenerator::AssembleBranchPoisoning(FlagsCondition condition,
 
   switch (instr->arch_opcode()) {
     case kRiscvCmp: {
-      __ LoadZeroOnCondition(kSpeculationPoisonRegister, i.InputRegister(0),
-                             i.InputOperand(1),
-                             FlagsConditionToConditionCmp(condition));
+      __ CompareI(kScratchReg, i.InputRegister(0), i.InputOperand(1),
+                  FlagsConditionToConditionCmp(condition));
+      __ LoadZeroIfConditionNotZero(kSpeculationPoisonRegister, kScratchReg);
     }
       return;
     case kRiscvTst: {

--- a/test/cctest/test-macro-assembler-riscv64.cc
+++ b/test/cctest/test-macro-assembler-riscv64.cc
@@ -1478,15 +1478,19 @@ static const std::vector<double> compare_double_test_values() {
 
 template <typename T>
 static bool Compare(T input1, T input2, FPUCondition cond) {
-  if (std::isnan(input1) || std::isnan(input2)) return false;
-
   switch (cond) {
-    case EQ:  // Equal.
+    case EQ:
       return (input1 == input2);
-    case LT:  // Ordered or Less Than
+    case LT:
       return (input1 < input2);
-    case LE:  // Ordered or Less Than or Equal
+    case LE:
       return (input1 <= input2);
+    case NE:
+      return (input1 != input2);
+    case GT:
+      return (input1 > input2);
+    case GE:
+      return (input1 >= input2);
     default:
       UNREACHABLE();
   }
@@ -1526,6 +1530,9 @@ TEST(FCompare32_Branch) {
   FCompare32Helper(EQ);
   FCompare32Helper(LT);
   FCompare32Helper(LE);
+  FCompare32Helper(NE);
+  FCompare32Helper(GT);
+  FCompare32Helper(GE);
 
   // test CompareIsNanF32: return true if any operand isnan
   auto fn = [](MacroAssembler* masm) { __ CompareIsNanF32(a1, fa0, fa1); };
@@ -1540,6 +1547,9 @@ TEST(FCompare64_Branch) {
   FCompare64Helper(EQ);
   FCompare64Helper(LT);
   FCompare64Helper(LE);
+  FCompare64Helper(NE);
+  FCompare64Helper(GT);
+  FCompare64Helper(GE);
 
   // test CompareIsNanF64: return true if any operand isnan
   auto fn = [](MacroAssembler* masm) { __ CompareIsNanF64(a1, fa0, fa1); };

--- a/test/cctest/test-macro-assembler-riscv64.cc
+++ b/test/cctest/test-macro-assembler-riscv64.cc
@@ -37,6 +37,7 @@
 #include "src/objects/objects-inl.h"
 #include "src/utils/ostreams.h"
 #include "test/cctest/cctest.h"
+#include "test/cctest/compiler/value-helper.h"
 
 namespace v8 {
 namespace internal {
@@ -414,8 +415,8 @@ static const std::vector<int64_t> cvt_trunc_int64_test_values() {
   return std::vector<int64_t>(&kValues[0], &kValues[arraysize(kValues)]);
 }
 
-// Helper macros that can be used in FOR_INT32_INPUTS(i) { ... *i ... }
-#define FOR_INPUTS(ctype, itype, var, test_vector)           \
+// Helper macros that can be used in FOR_INT32_INPUTS3(i) { ... *i ... }
+#define FOR_INPUTS3(ctype, itype, var, test_vector)          \
   std::vector<ctype> var##_vec = test_vector();              \
   for (std::vector<ctype>::iterator var = var##_vec.begin(); \
        var != var##_vec.end(); ++var)
@@ -427,24 +428,24 @@ static const std::vector<int64_t> cvt_trunc_int64_test_values() {
   for (var = var##_vec.begin(), var2 = var##_vec.rbegin(); \
        var != var##_vec.end(); ++var, ++var2)
 
-#define FOR_ENUM_INPUTS(var, type, test_vector) \
-  FOR_INPUTS(enum type, type, var, test_vector)
-#define FOR_STRUCT_INPUTS(var, type, test_vector) \
-  FOR_INPUTS(struct type, type, var, test_vector)
-#define FOR_INT32_INPUTS(var, test_vector) \
-  FOR_INPUTS(int32_t, int32, var, test_vector)
+// #define FOR_ENUM_INPUTS(var, type, test_vector) \
+//   FOR_INPUTS3(enum type, type, var, test_vector)
+// #define FOR_STRUCT_INPUTS(var, type, test_vector) \
+//   FOR_INPUTS3(struct type, type, var, test_vector)
+#define FOR_INT32_INPUTS3(var, test_vector) \
+  FOR_INPUTS3(int32_t, int32, var, test_vector)
 #define FOR_INT32_INPUTS2(var, var2, test_vector) \
   FOR_INPUTS2(int32_t, int32, var, var2, test_vector)
-#define FOR_INT64_INPUTS(var, test_vector) \
-  FOR_INPUTS(int64_t, int64, var, test_vector)
-#define FOR_UINT32_INPUTS(var, test_vector) \
-  FOR_INPUTS(uint32_t, uint32, var, test_vector)
-#define FOR_UINT64_INPUTS(var, test_vector) \
-  FOR_INPUTS(uint64_t, uint64, var, test_vector)
-#define FOR_FLOAT_INPUTS(var, test_vector) \
-  FOR_INPUTS(float, float, var, test_vector)
-#define FOR_DOUBLE_INPUTS(var, test_vector) \
-  FOR_INPUTS(double, double, var, test_vector)
+#define FOR_INT64_INPUTS3(var, test_vector) \
+  FOR_INPUTS3(int64_t, int64, var, test_vector)
+#define FOR_UINT32_INPUTS3(var, test_vector) \
+  FOR_INPUTS3(uint32_t, uint32, var, test_vector)
+#define FOR_UINT64_INPUTS3(var, test_vector) \
+  FOR_INPUTS3(uint64_t, uint64, var, test_vector)
+#define FOR_FLOAT_INPUTS3(var, test_vector) \
+  FOR_INPUTS3(float, float, var, test_vector)
+#define FOR_DOUBLE_INPUTS3(var, test_vector) \
+  FOR_INPUTS3(double, double, var, test_vector)
 
 template <typename RET_TYPE, typename IN_TYPE, typename Func>
 RET_TYPE run_Cvt(IN_TYPE x, Func GenerateConvertInstructionFunc) {
@@ -499,7 +500,7 @@ RET_TYPE run_Cvt(IN_TYPE x, Func GenerateConvertInstructionFunc) {
 
 TEST(Cvt_s_uw_Trunc_uw_s) {
   CcTest::InitializeVM();
-  FOR_UINT32_INPUTS(i, cvt_trunc_uint32_test_values) {
+  FOR_UINT32_INPUTS3(i, cvt_trunc_uint32_test_values) {
     uint32_t input = *i;
     auto fn = [](MacroAssembler* masm) {
       __ Cvt_s_uw(fa0, a0);
@@ -514,7 +515,7 @@ TEST(Cvt_s_uw_Trunc_uw_s) {
 
 TEST(Cvt_s_ul_Trunc_ul_s) {
   CcTest::InitializeVM();
-  FOR_UINT64_INPUTS(i, cvt_trunc_uint64_test_values) {
+  FOR_UINT64_INPUTS3(i, cvt_trunc_uint64_test_values) {
     uint64_t input = *i;
     auto fn = [](MacroAssembler* masm) {
       __ Cvt_s_ul(fa0, a0);
@@ -527,7 +528,7 @@ TEST(Cvt_s_ul_Trunc_ul_s) {
 
 TEST(Cvt_d_ul_Trunc_ul_d) {
   CcTest::InitializeVM();
-  FOR_UINT64_INPUTS(i, cvt_trunc_uint64_test_values) {
+  FOR_UINT64_INPUTS3(i, cvt_trunc_uint64_test_values) {
     uint64_t input = *i;
     auto fn = [](MacroAssembler* masm) {
       __ Cvt_d_ul(fa0, a0);
@@ -540,7 +541,7 @@ TEST(Cvt_d_ul_Trunc_ul_d) {
 
 TEST(cvt_d_l_Trunc_l_d) {
   CcTest::InitializeVM();
-  FOR_INT64_INPUTS(i, cvt_trunc_int64_test_values) {
+  FOR_INT64_INPUTS3(i, cvt_trunc_int64_test_values) {
     int64_t input = *i;
     auto fn = [](MacroAssembler* masm) {
       __ fcvt_d_l(fa0, a0);
@@ -553,7 +554,7 @@ TEST(cvt_d_l_Trunc_l_d) {
 
 TEST(cvt_d_w_Trunc_w_d) {
   CcTest::InitializeVM();
-  FOR_INT32_INPUTS(i, cvt_trunc_int32_test_values) {
+  FOR_INT32_INPUTS3(i, cvt_trunc_int32_test_values) {
     int32_t input = *i;
     auto fn = [](MacroAssembler* masm) {
       __ fcvt_d_w(fa0, a0);
@@ -600,8 +601,8 @@ TEST(OverflowInstructions) {
   };
   T t;
 
-  FOR_INT64_INPUTS(i, overflow_int64_test_values) {
-    FOR_INT64_INPUTS(j, overflow_int64_test_values) {
+  FOR_INT64_INPUTS3(i, overflow_int64_test_values) {
+    FOR_INT64_INPUTS3(j, overflow_int64_test_values) {
       int64_t ii = *i;
       int64_t jj = *j;
       int64_t expected_add, expected_sub;
@@ -821,7 +822,7 @@ TEST(Ulh) {
   char memory_buffer[kBufferSize];
   char* buffer_middle = memory_buffer + (kBufferSize / 2);
 
-  FOR_UINT64_INPUTS(i, unsigned_test_values) {
+  FOR_UINT64_INPUTS3(i, unsigned_test_values) {
     FOR_INT32_INPUTS2(j1, j2, unsigned_test_offset) {
       FOR_INT32_INPUTS2(k1, k2, unsigned_test_offset_increment) {
         uint16_t value = static_cast<uint64_t>(*i & 0xFFFF);
@@ -875,7 +876,7 @@ TEST(Ulh_bitextension) {
   char memory_buffer[kBufferSize];
   char* buffer_middle = memory_buffer + (kBufferSize / 2);
 
-  FOR_UINT64_INPUTS(i, unsigned_test_values) {
+  FOR_UINT64_INPUTS3(i, unsigned_test_values) {
     FOR_INT32_INPUTS2(j1, j2, unsigned_test_offset) {
       FOR_INT32_INPUTS2(k1, k2, unsigned_test_offset_increment) {
         uint16_t value = static_cast<uint64_t>(*i & 0xFFFF);
@@ -927,7 +928,7 @@ TEST(Ulw) {
   char memory_buffer[kBufferSize];
   char* buffer_middle = memory_buffer + (kBufferSize / 2);
 
-  FOR_UINT64_INPUTS(i, unsigned_test_values) {
+  FOR_UINT64_INPUTS3(i, unsigned_test_values) {
     FOR_INT32_INPUTS2(j1, j2, unsigned_test_offset) {
       FOR_INT32_INPUTS2(k1, k2, unsigned_test_offset_increment) {
         uint32_t value = static_cast<uint32_t>(*i & 0xFFFFFFFF);
@@ -983,7 +984,7 @@ TEST(Ulw_extension) {
   char memory_buffer[kBufferSize];
   char* buffer_middle = memory_buffer + (kBufferSize / 2);
 
-  FOR_UINT64_INPUTS(i, unsigned_test_values) {
+  FOR_UINT64_INPUTS3(i, unsigned_test_values) {
     FOR_INT32_INPUTS2(j1, j2, unsigned_test_offset) {
       FOR_INT32_INPUTS2(k1, k2, unsigned_test_offset_increment) {
         uint32_t value = static_cast<uint32_t>(*i & 0xFFFFFFFF);
@@ -1035,7 +1036,7 @@ TEST(Uld) {
   char memory_buffer[kBufferSize];
   char* buffer_middle = memory_buffer + (kBufferSize / 2);
 
-  FOR_UINT64_INPUTS(i, unsigned_test_values) {
+  FOR_UINT64_INPUTS3(i, unsigned_test_values) {
     FOR_INT32_INPUTS2(j1, j2, unsigned_test_offset) {
       FOR_INT32_INPUTS2(k1, k2, unsigned_test_offset_increment) {
         uint64_t value = *i;
@@ -1072,7 +1073,7 @@ TEST(ULoadFloat) {
   char memory_buffer[kBufferSize];
   char* buffer_middle = memory_buffer + (kBufferSize / 2);
 
-  FOR_UINT64_INPUTS(i, unsigned_test_values) {
+  FOR_UINT64_INPUTS3(i, unsigned_test_values) {
     FOR_INT32_INPUTS2(j1, j2, unsigned_test_offset) {
       FOR_INT32_INPUTS2(k1, k2, unsigned_test_offset_increment) {
         float value = static_cast<float>(*i & 0xFFFFFFFF);
@@ -1098,7 +1099,7 @@ TEST(ULoadDouble) {
   char memory_buffer[kBufferSize];
   char* buffer_middle = memory_buffer + (kBufferSize / 2);
 
-  FOR_UINT64_INPUTS(i, unsigned_test_values) {
+  FOR_UINT64_INPUTS3(i, unsigned_test_values) {
     FOR_INT32_INPUTS2(j1, j2, unsigned_test_offset) {
       FOR_INT32_INPUTS2(k1, k2, unsigned_test_offset_increment) {
         double value = static_cast<double>(*i);
@@ -1138,7 +1139,7 @@ static const std::vector<uint64_t> sltu_test_values() {
 }
 
 template <typename Func>
-bool run_Sltu(uint64_t rs, uint64_t rd, Func GenerateSltuInstructionFunc) {
+bool run_Compare(uint64_t rs, uint64_t rd, Func GenerateCompareFunc) {
   using F_CVT = int64_t(uint64_t x0, uint64_t x1);
 
   Isolate* isolate = CcTest::i_isolate();
@@ -1146,7 +1147,7 @@ bool run_Sltu(uint64_t rs, uint64_t rd, Func GenerateSltuInstructionFunc) {
   MacroAssembler assm(isolate, v8::internal::CodeObjectRequired::kYes);
   MacroAssembler* masm = &assm;
 
-  GenerateSltuInstructionFunc(masm, rd);
+  GenerateCompareFunc(masm, rd);
   __ jr(ra);
 
   CodeDesc desc;
@@ -1162,20 +1163,22 @@ bool run_Sltu(uint64_t rs, uint64_t rd, Func GenerateSltuInstructionFunc) {
 TEST(Sltu) {
   CcTest::InitializeVM();
 
-  FOR_UINT64_INPUTS(i, sltu_test_values) {
-    FOR_UINT64_INPUTS(j, sltu_test_values) {
+  FOR_UINT64_INPUTS3(i, sltu_test_values) {
+    FOR_UINT64_INPUTS3(j, sltu_test_values) {
       uint64_t rs = *i;
       uint64_t rd = *j;
 
+      // compare against immediate field
       auto fn_1 = [](MacroAssembler* masm, uint64_t imm) {
         __ Sltu(a0, a0, Operand(imm));
       };
-      CHECK_EQ(rs < rd, run_Sltu(rs, rd, fn_1));
+      CHECK_EQ(rs < rd, run_Compare(rs, rd, fn_1));
 
+      // compare against register
       auto fn_2 = [](MacroAssembler* masm, uint64_t imm) {
         __ Sltu(a0, a0, a1);
       };
-      CHECK_EQ(rs < rd, run_Sltu(rs, rd, fn_2));
+      CHECK_EQ(rs < rd, run_Compare(rs, rd, fn_2));
     }
   }
 }
@@ -1463,7 +1466,6 @@ int32_t run_CompareF(IN_TYPE x1, IN_TYPE x2, bool expected_res,
   }
 }
 
-// FIXME (RISCV): add tests for NaN, infinity, etc
 static const std::vector<float> compare_float_test_values() {
   static const float kValues[] = {0.0f,  -0.0f,  100.23f, -1034.78f, max_f,
                                   min_f, qnan_f, inf_f,   -inf_f};
@@ -1477,7 +1479,7 @@ static const std::vector<double> compare_double_test_values() {
 }
 
 template <typename T>
-static bool Compare(T input1, T input2, FPUCondition cond) {
+static bool CompareF(T input1, T input2, FPUCondition cond) {
   switch (cond) {
     case EQ:
       return (input1 == input2);
@@ -1496,12 +1498,42 @@ static bool Compare(T input1, T input2, FPUCondition cond) {
   }
 }
 
+static bool CompareU(uint64_t input1, uint64_t input2, Condition cond) {
+  switch (cond) {
+    case eq:
+      return (input1 == input2);
+    case ne:
+      return (input1 != input2);
+
+    case Uless:
+      return (input1 < input2);
+    case Uless_equal:
+      return (input1 <= input2);
+    case Ugreater:
+      return (input1 > input2);
+    case Ugreater_equal:
+      return (input1 >= input2);
+
+    case less:
+      return (static_cast<int64_t>(input1) < static_cast<int64_t>(input2));
+    case less_equal:
+      return (static_cast<int64_t>(input1) <= static_cast<int64_t>(input2));
+    case greater:
+      return (static_cast<int64_t>(input1) > static_cast<int64_t>(input2));
+    case greater_equal:
+      return (static_cast<int64_t>(input1) >= static_cast<int64_t>(input2));
+
+    default:
+      UNREACHABLE();
+  }
+}
+
 static void FCompare32Helper(FPUCondition cond) {
-  FOR_FLOAT_INPUTS(i, compare_float_test_values) {
-    FOR_FLOAT_INPUTS(j, compare_float_test_values) {
+  FOR_FLOAT_INPUTS3(i, compare_float_test_values) {
+    FOR_FLOAT_INPUTS3(j, compare_float_test_values) {
       auto input1 = *i;
       auto input2 = *j;
-      bool comp_res = Compare(input1, input2, cond);
+      bool comp_res = CompareF(input1, input2, cond);
       auto fn = [cond](MacroAssembler* masm) {
         __ CompareF32(a1, cond, fa0, fa1);
       };
@@ -1511,11 +1543,11 @@ static void FCompare32Helper(FPUCondition cond) {
 }
 
 static void FCompare64Helper(FPUCondition cond) {
-  FOR_DOUBLE_INPUTS(i, compare_double_test_values) {
-    FOR_DOUBLE_INPUTS(j, compare_double_test_values) {
+  FOR_DOUBLE_INPUTS3(i, compare_double_test_values) {
+    FOR_DOUBLE_INPUTS3(j, compare_double_test_values) {
       auto input1 = *i;
       auto input2 = *j;
-      bool comp_res = Compare(input1, input2, cond);
+      bool comp_res = CompareF(input1, input2, cond);
       auto fn = [cond](MacroAssembler* masm) {
         __ CompareF64(a1, cond, fa0, fa1);
       };
@@ -1559,6 +1591,40 @@ TEST(FCompare64_Branch) {
   CHECK_EQ(SUCCESS_CODE, run_CompareF(snan_d, qnan_d, true, fn));
 }
 
+static void CompareIHelper(Condition cond) {
+  auto fn1 = [cond](MacroAssembler* masm, int64_t imm) {
+    __ CompareI(a0, a0, Operand(imm), cond);
+  };
+  auto fn2 = [cond](MacroAssembler* masm, int64_t imm) {
+    __ CompareI(a0, a0, Operand(a1), cond);
+  };
+  FOR_UINT64_INPUTS(i) {
+    FOR_UINT64_INPUTS(j) {
+      auto input1 = i;
+      auto input2 = j;
+      bool comp_res = CompareU(input1, input2, cond);
+      CHECK_EQ(comp_res, run_Compare(input1, input2, fn1));
+      CHECK_EQ(comp_res, run_Compare(input1, input2, fn2));
+    }
+  }
+}
+
+TEST(CompareI) {
+  CcTest::InitializeVM();
+  CompareIHelper(eq);
+  CompareIHelper(ne);
+
+  CompareIHelper(greater);
+  CompareIHelper(greater_equal);
+  CompareIHelper(less);
+  CompareIHelper(less_equal);
+
+  CompareIHelper(Ugreater);
+  CompareIHelper(Ugreater_equal);
+  CompareIHelper(Uless);
+  CompareIHelper(Uless_equal);
+}
+
 static const std::vector<uint32_t> cltz_uint32_test_values() {
   static const uint32_t kValues[] = {0x00000001, 0x00FFFF00, 0x7FFBD100,
                                      0x00123400, 0x0000FF10, 0x20FFFF00,
@@ -1576,7 +1642,7 @@ static const std::vector<uint64_t> cltz_uint64_test_values() {
 
 TEST(Clz32) {
   CcTest::InitializeVM();
-  FOR_UINT32_INPUTS(i, cltz_uint32_test_values) {
+  FOR_UINT32_INPUTS3(i, cltz_uint32_test_values) {
     uint32_t input = *i;
     auto fn = [](MacroAssembler* masm) { __ Clz32(a0, a0); };
     CHECK_EQ(__builtin_clz(input), run_Cvt<int>(input, fn));
@@ -1585,7 +1651,7 @@ TEST(Clz32) {
 
 TEST(Ctz32) {
   CcTest::InitializeVM();
-  FOR_UINT32_INPUTS(i, cltz_uint32_test_values) {
+  FOR_UINT32_INPUTS3(i, cltz_uint32_test_values) {
     uint32_t input = *i;
     auto fn = [](MacroAssembler* masm) { __ Ctz32(a0, a0); };
     CHECK_EQ(__builtin_ctz(input), run_Cvt<int>(input, fn));
@@ -1594,7 +1660,7 @@ TEST(Ctz32) {
 
 TEST(Clz64) {
   CcTest::InitializeVM();
-  FOR_UINT64_INPUTS(i, cltz_uint64_test_values) {
+  FOR_UINT64_INPUTS3(i, cltz_uint64_test_values) {
     uint64_t input = *i;
     auto fn = [](MacroAssembler* masm) { __ Clz64(a0, a0); };
     CHECK_EQ(__builtin_clzll(input), run_Cvt<int>(input, fn));
@@ -1603,7 +1669,7 @@ TEST(Clz64) {
 
 TEST(Ctz64) {
   CcTest::InitializeVM();
-  FOR_UINT64_INPUTS(i, cltz_uint64_test_values) {
+  FOR_UINT64_INPUTS3(i, cltz_uint64_test_values) {
     uint64_t input = *i;
     auto fn = [](MacroAssembler* masm) { __ Ctz64(a0, a0); };
     CHECK_EQ(__builtin_ctzll(input), run_Cvt<int>(input, fn));


### PR DESCRIPTION
Refactor MIPS legacy of using conditional move (e.g., `Movn`, `Movz`, `LoadZeroOnCondition`, and negation of conditional codes) to implement compare. Instead, we use straightforward compare instructions to implement these logics on RISC-V to generate more efficient instructions.

This PR has straightened out most places that use condition code except for the floating-point compare used in `code-generator-riscv64.cc`, where a subtle negation logic using `predicate` still remains (a first attempt at refactoring the predicates away resulted in strange errors), will have to try it in a separate PR.

Fixes #185 