### PR TITLE
Skip the on-heap trampoline for builtin calls

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -4179,6 +4179,10 @@ v8_component("v8_libbase") {
     sources += [ "src/base/ubsan.cc" ]
   }
 
+  if(v8_current_cpu == "riscv" || v8_current_cpu == "riscv64"){
+    libs += [ "atomic" ]
+  }
+
   if (is_tsan && !build_with_chromium) {
     data += [ "tools/sanitizers/tsan_suppressions.txt" ]
   }

--- a/src/builtins/riscv64/builtins-riscv64.cc
+++ b/src/builtins/riscv64/builtins-riscv64.cc
@@ -461,8 +461,7 @@ void Builtins::Generate_ResumeGeneratorTrampoline(MacroAssembler* masm) {
     __ Move(a1, a4);
     static_assert(kJavaScriptCallCodeStartRegister == a2, "ABI mismatch");
     __ Ld(a2, FieldMemOperand(a1, JSFunction::kCodeOffset));
-    __ Add64(a2, a2, Operand(Code::kHeaderSize - kHeapObjectTag));
-    __ Jump(a2);
+    __ JumpCodeObject(a2);
   }
 
   __ bind(&prepare_step_in_if_stepping);
@@ -879,8 +878,7 @@ static void TailCallOptimizedCodeSlot(MacroAssembler* masm,
                                       scratch1, scratch2);
 
   static_assert(kJavaScriptCallCodeStartRegister == a2, "ABI mismatch");
-  __ Add64(a2, optimized_code_entry,
-           Operand(Code::kHeaderSize - kHeapObjectTag));
+  __ LoadCodeObjectEntry(a2, optimized_code_entry);
   __ Jump(a2);
 
   // Optimized code slot contains deoptimized code, evict it and re-enter the
@@ -2491,8 +2489,7 @@ void Builtins::Generate_ArgumentsAdaptorTrampoline(MacroAssembler* masm) {
   // a3: new target (passed through to callee)
   static_assert(kJavaScriptCallCodeStartRegister == a2, "ABI mismatch");
   __ Ld(a2, FieldMemOperand(a1, JSFunction::kCodeOffset));
-  __ Add64(a2, a2, Operand(Code::kHeaderSize - kHeapObjectTag));
-  __ Call(a2);
+  __ CallCodeObject(a2);
 
   // Store offset of return address for deoptimizer.
   masm->isolate()->heap()->SetArgumentsAdaptorDeoptPCOffset(masm->pc_offset());
@@ -2507,8 +2504,8 @@ void Builtins::Generate_ArgumentsAdaptorTrampoline(MacroAssembler* masm) {
   __ bind(&dont_adapt_arguments);
   static_assert(kJavaScriptCallCodeStartRegister == a2, "ABI mismatch");
   __ Ld(a2, FieldMemOperand(a1, JSFunction::kCodeOffset));
-  __ Add64(a2, a2, Operand(Code::kHeaderSize - kHeapObjectTag));
-  __ Jump(a2);
+
+  __ JumpCodeObject(a2);
 
   __ bind(&stack_overflow);
   {

--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -2921,24 +2921,28 @@ void TurboAssembler::Jump(Handle<Code> code, RelocInfo::Mode rmode,
   DCHECK(RelocInfo::IsCodeTarget(rmode));
 
   BlockTrampolinePoolScope block_trampoline_pool(this);
-  if (root_array_available_ && options().isolate_independent_code) {
-    IndirectLoadConstant(t6, code);
-    Add64(t6, t6, Operand(Code::kHeaderSize - kHeapObjectTag));
+  int builtin_index = Builtins::kNoBuiltinId;
+  bool target_is_isolate_independent_builtin =
+      isolate()->builtins()->IsBuiltinHandle(code, &builtin_index) &&
+      Builtins::IsIsolateIndependent(builtin_index);
+
+  if (root_array_available_ && options().isolate_independent_code &&
+      target_is_isolate_independent_builtin) {
+    int offset = code->builtin_index() * kSystemPointerSize +
+                 IsolateData::builtin_entry_table_offset();
+    Ld(t6, MemOperand(kRootRegister, offset));
     Jump(t6, cond, rs, rt);
     return;
-  } else if (options().inline_offheap_trampolines) {
-    int builtin_index = Builtins::kNoBuiltinId;
-    if (isolate()->builtins()->IsBuiltinHandle(code, &builtin_index) &&
-        Builtins::IsIsolateIndependent(builtin_index)) {
-      // Inline the trampoline.
-      RecordCommentForOffHeapTrampoline(builtin_index);
-      CHECK_NE(builtin_index, Builtins::kNoBuiltinId);
-      EmbeddedData d = EmbeddedData::FromBlob();
-      Address entry = d.InstructionStartOfBuiltin(builtin_index);
-      li(t6, Operand(entry, RelocInfo::OFF_HEAP_TARGET));
-      Jump(t6, cond, rs, rt);
-      return;
-    }
+  } else if (options().inline_offheap_trampolines &&
+             target_is_isolate_independent_builtin) {
+    // Inline the trampoline.
+    RecordCommentForOffHeapTrampoline(builtin_index);
+    CHECK_NE(builtin_index, Builtins::kNoBuiltinId);
+    EmbeddedData d = EmbeddedData::FromBlob();
+    Address entry = d.InstructionStartOfBuiltin(builtin_index);
+    li(t6, Operand(entry, RelocInfo::OFF_HEAP_TARGET));
+    Jump(t6, cond, rs, rt);
+    return;
   }
 
   Jump(static_cast<intptr_t>(code.address()), rmode, cond, rs, rt);
@@ -2989,24 +2993,27 @@ void TurboAssembler::Call(Handle<Code> code, RelocInfo::Mode rmode,
                           Condition cond, Register rs, const Operand& rt) {
   BlockTrampolinePoolScope block_trampoline_pool(this);
 
-  if (root_array_available_ && options().isolate_independent_code) {
-    IndirectLoadConstant(t6, code);
-    Add64(t6, t6, Operand(Code::kHeaderSize - kHeapObjectTag));
+  int builtin_index = Builtins::kNoBuiltinId;
+  bool target_is_isolate_independent_builtin =
+      isolate()->builtins()->IsBuiltinHandle(code, &builtin_index) &&
+      Builtins::IsIsolateIndependent(builtin_index);
+  if (root_array_available_ && options().isolate_independent_code &&
+     target_is_isolate_independent_builtin) {
+    int offset = code->builtin_index() * kSystemPointerSize +
+                 IsolateData::builtin_entry_table_offset();
+    LoadRootRelative(t6, offset);
     Call(t6, cond, rs, rt);
     return;
-  } else if (options().inline_offheap_trampolines) {
-    int builtin_index = Builtins::kNoBuiltinId;
-    if (isolate()->builtins()->IsBuiltinHandle(code, &builtin_index) &&
-        Builtins::IsIsolateIndependent(builtin_index)) {
-      // Inline the trampoline.
-      RecordCommentForOffHeapTrampoline(builtin_index);
-      CHECK_NE(builtin_index, Builtins::kNoBuiltinId);
-      EmbeddedData d = EmbeddedData::FromBlob();
-      Address entry = d.InstructionStartOfBuiltin(builtin_index);
-      li(t6, Operand(entry, RelocInfo::OFF_HEAP_TARGET));
-      Call(t6, cond, rs, rt);
-      return;
-    }
+  } else if (options().inline_offheap_trampolines &&
+             target_is_isolate_independent_builtin) {
+    // Inline the trampoline.
+    RecordCommentForOffHeapTrampoline(builtin_index);
+    CHECK_NE(builtin_index, Builtins::kNoBuiltinId);
+    EmbeddedData d = EmbeddedData::FromBlob();
+    Address entry = d.InstructionStartOfBuiltin(builtin_index);
+    li(t6, Operand(entry, RelocInfo::OFF_HEAP_TARGET));
+    Call(t6, cond, rs, rt);
+    return;
   }
 
   DCHECK(RelocInfo::IsCodeTarget(rmode));
@@ -3410,12 +3417,10 @@ void MacroAssembler::InvokeFunctionCode(Register function, Register new_target,
   Register code = kJavaScriptCallCodeStartRegister;
   Ld(code, FieldMemOperand(function, JSFunction::kCodeOffset));
   if (flag == CALL_FUNCTION) {
-    Add64(code, code, Operand(Code::kHeaderSize - kHeapObjectTag));
-    Call(code);
+    CallCodeObject(code);
   } else {
     DCHECK(flag == JUMP_FUNCTION);
-    Add64(code, code, Operand(Code::kHeaderSize - kHeapObjectTag));
-    Jump(code);
+    JumpCodeObject(code);
   }
 
   // Continue here if InvokePrologue does handle the invocation due to
@@ -4328,6 +4333,65 @@ void TurboAssembler::CallForDeoptimization(Address target, int deopt_id,
   DCHECK_LE(deopt_id, 0xFFFF);
   li(kRootRegister, deopt_id);
   Call(target, RelocInfo::RUNTIME_ENTRY);
+}
+
+void TurboAssembler::LoadCodeObjectEntry(Register destination,
+                                         Register code_object) {
+  // Code objects are called differently depending on whether we are generating
+  // builtin code (which will later be embedded into the binary) or compiling
+  // user JS code at runtime.
+  // * Builtin code runs in --jitless mode and thus must not call into on-heap
+  //   Code targets. Instead, we dispatch through the builtins entry table.
+  // * Codegen at runtime does not have this restriction and we can use the
+  //   shorter, branchless instruction sequence. The assumption here is that
+  //   targets are usually generated code and not builtin Code objects.
+  if (options().isolate_independent_code) {
+    DCHECK(root_array_available());
+    Label if_code_is_off_heap,no_builtin_index, out;
+    UseScratchRegisterScope temps(this);
+    Register scratch = temps.Acquire();
+
+    DCHECK(!AreAliased(destination, scratch));
+    DCHECK(!AreAliased(code_object, scratch));
+
+    // Check whether the Code object is an off-heap trampoline. If so, call its
+    // (off-heap) entry point directly without going through the (on-heap)
+    // trampoline.  Otherwise, just call the Code object as always.
+    Lw(scratch, FieldMemOperand(code_object, Code::kFlagsOffset));
+    Branch(&if_code_is_off_heap, ne, scratch,
+         Operand(Code::IsOffHeapTrampoline::kMask));
+    // Not an off-heap trampoline object, the entry point is at
+    // Code::raw_instruction_start().
+    bind(&no_builtin_index);
+    Add64(destination, code_object, Code::kHeaderSize - kHeapObjectTag);
+    Branch(&out);
+
+    // An off-heap trampoline, the entry point is loaded from the builtin entry
+    // table.
+    bind(&if_code_is_off_heap);
+    Lw(scratch, FieldMemOperand(code_object, Code::kBuiltinIndexOffset));
+    //FIXME(RISCV64):on other arch, don't need no_builtin_index.
+    Branch(&no_builtin_index, eq, scratch, Operand(Builtins::kNoBuiltinId));
+    slli(destination, scratch, kSystemPointerSizeLog2);
+    Add64(destination, destination, kRootRegister);
+    Ld(destination,
+        MemOperand(destination, IsolateData::builtin_entry_table_offset()));
+
+    bind(&out);
+  } else {
+    Add64(destination, code_object, Code::kHeaderSize - kHeapObjectTag);
+  }
+}
+
+
+void TurboAssembler::CallCodeObject(Register code_object) {
+  LoadCodeObjectEntry(code_object, code_object);
+  Call(code_object);
+}
+
+void TurboAssembler::JumpCodeObject(Register code_object) {
+  LoadCodeObjectEntry(code_object, code_object);
+  Jump(code_object);
 }
 
 }  // namespace internal

--- a/src/codegen/riscv64/macro-assembler-riscv64.h
+++ b/src/codegen/riscv64/macro-assembler-riscv64.h
@@ -216,19 +216,10 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   void CallBuiltinByIndex(Register builtin_index) override;
 
   void LoadCodeObjectEntry(Register destination,
-                           Register code_object) override {
-    // TODO(RISCV): Implement.
-    UNIMPLEMENTED();
-  }
-  void CallCodeObject(Register code_object) override {
-    // TODO(RISCV): Implement.
-    UNIMPLEMENTED();
-  }
-  void JumpCodeObject(Register code_object) override {
-    // TODO(RISCV): Implement.
-    UNIMPLEMENTED();
-  }
-
+                           Register code_object) override;
+  void CallCodeObject(Register code_object) override;
+  void JumpCodeObject(Register code_object) override;
+  
   // Generates an instruction sequence s.t. the return address points to the
   // instruction following the call.
   // The return address on the stack is used by frame iteration.

--- a/src/compiler/backend/riscv64/code-generator-riscv64.cc
+++ b/src/compiler/backend/riscv64/code-generator-riscv64.cc
@@ -609,8 +609,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
         DCHECK_IMPLIES(
             HasCallDescriptorFlag(instr, CallDescriptor::kFixedTargetRegister),
             reg == kJavaScriptCallCodeStartRegister);
-        __ Add64(reg, reg, Code::kHeaderSize - kHeapObjectTag);
-        __ Call(reg);
+        __ CallCodeObject(reg);
       }
       RecordCallPosition(instr);
       frame_access_state()->ClearSPDelta();
@@ -657,8 +656,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
         DCHECK_IMPLIES(
             HasCallDescriptorFlag(instr, CallDescriptor::kFixedTargetRegister),
             reg == kJavaScriptCallCodeStartRegister);
-        __ Add64(reg, reg, Code::kHeaderSize - kHeapObjectTag);
-        __ Jump(reg);
+        __ JumpCodeObject(reg);
       }
       frame_access_state()->ClearSPDelta();
       frame_access_state()->SetFrameAccessToDefault();
@@ -698,8 +696,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       }
       static_assert(kJavaScriptCallCodeStartRegister == a2, "ABI mismatch");
       __ Ld(a2, FieldMemOperand(func, JSFunction::kCodeOffset));
-      __ Add64(a2, a2, Operand(Code::kHeaderSize - kHeapObjectTag));
-      __ Call(a2);
+      __ CallCodeObject(a2);
       RecordCallPosition(instr);
       frame_access_state()->ClearSPDelta();
       break;


### PR DESCRIPTION
If using on-heao trampoline, d8 running jitless mode will be crash.
Refer to https://chromium-review.googlesource.com/c/v8/v8/+/1382461