### PR TITLE
Fix constant error and alter range when load a constant.

### DIFF
--- a/src/codegen/constant-pool.cc
+++ b/src/codegen/constant-pool.cc
@@ -211,7 +211,7 @@ int ConstantPoolBuilder::Emit(Assembler* assm) {
 
 #endif  // defined(V8_TARGET_ARCH_PPC) || defined(V8_TARGET_ARCH_PPC64)
 
-#if defined(V8_TARGET_ARCH_ARM64) || defined(V8_TARGET_ARCH_RISCV64)
+#if defined(V8_TARGET_ARCH_ARM64) 
 
 // Constant Pool.
 
@@ -458,6 +458,265 @@ void ConstantPool::MaybeCheck() {
 }
 
 #endif  // defined(V8_TARGET_ARCH_ARM64)
+
+#if defined(V8_TARGET_ARCH_RISCV64)
+
+// Constant Pool.
+
+ConstantPool::ConstantPool(Assembler* assm) : assm_(assm) {}
+ConstantPool::~ConstantPool() { DCHECK_EQ(blocked_nesting_, 0); }
+
+RelocInfoStatus ConstantPool::RecordEntry(uint32_t data,
+                                          RelocInfo::Mode rmode) {
+  ConstantPoolKey key(data, rmode);
+  CHECK(key.is_value32());
+  return RecordKey(std::move(key), assm_->pc_offset());
+}
+
+RelocInfoStatus ConstantPool::RecordEntry(uint64_t data,
+                                          RelocInfo::Mode rmode) {
+  ConstantPoolKey key(data, rmode);
+  CHECK(!key.is_value32());
+  return RecordKey(std::move(key), assm_->pc_offset());
+}
+
+RelocInfoStatus ConstantPool::RecordKey(ConstantPoolKey key, int offset) {
+  RelocInfoStatus write_reloc_info = GetRelocInfoStatusFor(key);
+  if (write_reloc_info == RelocInfoStatus::kMustRecord) {
+    if (key.is_value32()) {
+      if (entry32_count_ == 0) first_use_32_ = offset;
+      ++entry32_count_;
+    } else {
+      if (entry64_count_ == 0) first_use_64_ = offset;
+      ++entry64_count_;
+    }
+  }
+  entries_.insert(std::make_pair(key, offset));
+
+  if (Entry32Count() + Entry64Count() > ConstantPool::kApproxMaxEntryCount) {
+    // Request constant pool emission after the next instruction.
+    SetNextCheckIn(1);
+  }
+
+  return write_reloc_info;
+}
+
+RelocInfoStatus ConstantPool::GetRelocInfoStatusFor(
+    const ConstantPoolKey& key) {
+  if (key.AllowsDeduplication()) {
+    auto existing = entries_.find(key);
+    if (existing != entries_.end()) {
+      return RelocInfoStatus::kMustOmitForDuplicate;
+    }
+  }
+  return RelocInfoStatus::kMustRecord;
+}
+
+void ConstantPool::EmitAndClear(Jump require_jump) {
+  DCHECK(!IsBlocked());
+  // Prevent recursive pool emission.
+  Assembler::BlockPoolsScope block_pools(assm_, PoolEmissionCheck::kSkip);
+  Alignment require_alignment =
+      IsAlignmentRequiredIfEmittedAt(require_jump, assm_->pc_offset());
+  int size = ComputeSize(require_jump, require_alignment);
+  Label size_check;
+  assm_->bind(&size_check);
+  assm_->RecordConstPool(size);
+
+  // Emit the constant pool. It is preceded by an optional branch if
+  // {require_jump} and a header which will:
+  //  1) Encode the size of the constant pool, for use by the disassembler.
+  //  2) Terminate the program, to try to prevent execution from accidentally
+  //     flowing into the constant pool.
+  //  3) align the 64bit pool entries to 64-bit.
+  // TODO(all): Make the alignment part less fragile. Currently code is
+  // allocated as a byte array so there are no guarantees the alignment will
+  // be preserved on compaction. Currently it works as allocation seems to be
+  // 64-bit aligned.
+  DEBUG_PRINTF("\tConstant Pool start\n")
+  Label after_pool;
+  if (require_jump == Jump::kRequired) assm_->b(&after_pool);
+
+  assm_->RecordComment("[ Constant Pool");
+  
+  EmitPrologue(require_alignment);
+  if (require_alignment == Alignment::kRequired) assm_->DataAlign(kInt64Size);
+  EmitEntries();
+  assm_->RecordComment("]");
+  assm_->bind(&after_pool);
+  DEBUG_PRINTF("\tConstant Pool end\n")
+
+  DCHECK_LE(assm_->SizeOfCodeGeneratedSince(&size_check) - size, 3);
+  Clear();
+}
+
+void ConstantPool::Clear() {
+  entries_.clear();
+  first_use_32_ = -1;
+  first_use_64_ = -1;
+  entry32_count_ = 0;
+  entry64_count_ = 0;
+  next_check_ = 0;
+}
+
+void ConstantPool::StartBlock() {
+  if (blocked_nesting_ == 0) {
+    // Prevent constant pool checks from happening by setting the next check to
+    // the biggest possible offset.
+    next_check_ = kMaxInt;
+  }
+  ++blocked_nesting_;
+}
+
+void ConstantPool::EndBlock() {
+  --blocked_nesting_;
+  if (blocked_nesting_ == 0) {
+    DCHECK(IsInImmRangeIfEmittedAt(assm_->pc_offset()));
+    // Make sure a check happens quickly after getting unblocked.
+    next_check_ = 0;
+  }
+}
+
+bool ConstantPool::IsBlocked() const { return blocked_nesting_ > 0; }
+
+void ConstantPool::SetNextCheckIn(size_t instructions) {
+  next_check_ =
+      assm_->pc_offset() + static_cast<int>(instructions * kInstrSize);
+}
+
+void ConstantPool::EmitEntries() {
+  for (auto iter = entries_.begin(); iter != entries_.end();) {
+    DCHECK(iter->first.is_value32() || IsAligned(assm_->pc_offset(), 8));
+    auto range = entries_.equal_range(iter->first);
+    bool shared = iter->first.AllowsDeduplication();
+    for (auto it = range.first; it != range.second; ++it) {
+      SetLoadOffsetToConstPoolEntry(it->second, assm_->pc(), it->first);
+      if (!shared) Emit(it->first);
+    }
+    if (shared) Emit(iter->first);
+    iter = range.second;
+  }
+}
+
+void ConstantPool::Emit(const ConstantPoolKey& key) {
+  if (key.is_value32()) {
+    assm_->dd(key.value32());
+  } else {
+    assm_->dq(key.value64());
+  }
+}
+
+bool ConstantPool::ShouldEmitNow(Jump require_jump, size_t margin) const {
+  DEBUG_PRINTF("ShouldEmitNow\n");
+  if (IsEmpty()) return false;
+  if (Entry32Count() + Entry64Count() > ConstantPool::kApproxMaxEntryCount) {
+    DEBUG_PRINTF("> ConstantPool::kApproxMaxEntryCount\n");
+    return true;
+  }
+  // We compute {dist32/64}, i.e. the distance from the first instruction
+  // accessing a 32bit/64bit entry in the constant pool to any of the
+  // 32bit/64bit constant pool entries, respectively. This is required because
+  // we do not guarantee that entries are emitted in order of reference, i.e. it
+  // is possible that the entry with the earliest reference is emitted last.
+  // The constant pool should be emitted if either of the following is true:
+  // (A) {dist32/64} will be out of range at the next check in.
+  // (B) Emission can be done behind an unconditional branch and {dist32/64}
+  // exceeds {kOpportunityDist*}.
+  // (C) {dist32/64} exceeds the desired approximate distance to the pool.
+  int worst_case_size = ComputeSize(Jump::kRequired, Alignment::kRequired);
+  size_t pool_end_32 = assm_->pc_offset() + margin + worst_case_size;
+  size_t pool_end_64 = pool_end_32 - Entry32Count() * kInt32Size;
+  if (Entry64Count() != 0) {
+    // The 64-bit constants are always emitted before the 32-bit constants, so
+    // we subtract the size of the 32-bit constants from {size}.
+    size_t dist64 = pool_end_64 - first_use_64_;
+    bool next_check_too_late = dist64 + 2 * kCheckInterval >= kMaxDistToPool64;
+    bool opportune_emission_without_jump =
+        require_jump == Jump::kOmitted && (dist64 >= kOpportunityDistToPool64);
+    bool approximate_distance_exceeded = dist64 >= kApproxDistToPool64;
+    if (next_check_too_late || opportune_emission_without_jump ||
+        approximate_distance_exceeded) {
+      DEBUG_PRINTF("Entry64Count true:%d,%d,%d\n",next_check_too_late,
+                   opportune_emission_without_jump,
+                   approximate_distance_exceeded);
+      DEBUG_PRINTF("%zu,%zu,%zu\n",dist64,kCheckInterval,kMaxDistToPool64);
+      DEBUG_PRINTF("%lu,%zu\n",dist64 + 2 * kCheckInterval,kMaxDistToPool64);
+      return true;
+    }
+  }
+  if (Entry32Count() != 0) {
+    size_t dist32 = pool_end_32 - first_use_32_;
+    bool next_check_too_late = dist32 + 2 * kCheckInterval >= kMaxDistToPool32;
+    bool opportune_emission_without_jump =
+        require_jump == Jump::kOmitted && (dist32 >= kOpportunityDistToPool32);
+    bool approximate_distance_exceeded = dist32 >= kApproxDistToPool32;
+    if (next_check_too_late || opportune_emission_without_jump ||
+        approximate_distance_exceeded) {
+    DEBUG_PRINTF("Entry32Count true:%d,%d,%d\n",next_check_too_late,
+        opportune_emission_without_jump,
+        approximate_distance_exceeded);
+      return true;
+    }
+  }
+  return false;
+}
+
+int ConstantPool::ComputeSize(Jump require_jump,
+                              Alignment require_alignment) const {
+  int size_up_to_marker = PrologueSize(require_jump);
+  int alignment = require_alignment == Alignment::kRequired ? kInstrSize : 0;
+  size_t size_after_marker =
+      Entry32Count() * kInt32Size + alignment + Entry64Count() * kInt64Size;
+  return size_up_to_marker + static_cast<int>(size_after_marker);
+}
+
+Alignment ConstantPool::IsAlignmentRequiredIfEmittedAt(Jump require_jump,
+                                                       int pc_offset) const {
+  int size_up_to_marker = PrologueSize(require_jump);
+  if (Entry64Count() != 0 &&
+      !IsAligned(pc_offset + size_up_to_marker, kInt64Size)) {
+    return Alignment::kRequired;
+  }
+  return Alignment::kOmitted;
+}
+
+bool ConstantPool::IsInImmRangeIfEmittedAt(int pc_offset) {
+  // Check that all entries are in range if the pool is emitted at {pc_offset}.
+  // This ignores kPcLoadDelta (conservatively, since all offsets are positive),
+  // and over-estimates the last entry's address with the pool's end.
+  Alignment require_alignment =
+      IsAlignmentRequiredIfEmittedAt(Jump::kRequired, pc_offset);
+  size_t pool_end_32 =
+      pc_offset + ComputeSize(Jump::kRequired, require_alignment);
+  size_t pool_end_64 = pool_end_32 - Entry32Count() * kInt32Size;
+  bool entries_in_range_32 =
+      Entry32Count() == 0 || (pool_end_32 < first_use_32_ + kMaxDistToPool32);
+  bool entries_in_range_64 =
+      Entry64Count() == 0 || (pool_end_64 < first_use_64_ + kMaxDistToPool64);
+  return entries_in_range_32 && entries_in_range_64;
+}
+
+ConstantPool::BlockScope::BlockScope(Assembler* assm, size_t margin)
+    : pool_(&assm->constpool_) {
+  pool_->assm_->EmitConstPoolWithJumpIfNeeded(margin);
+  pool_->StartBlock();
+}
+
+ConstantPool::BlockScope::BlockScope(Assembler* assm, PoolEmissionCheck check)
+    : pool_(&assm->constpool_) {
+  DCHECK_EQ(check, PoolEmissionCheck::kSkip);
+  pool_->StartBlock();
+}
+
+ConstantPool::BlockScope::~BlockScope() { pool_->EndBlock(); }
+
+void ConstantPool::MaybeCheck() {
+  if (assm_->pc_offset() >= next_check_) {
+    Check(Emission::kIfNeeded, Jump::kRequired);
+  }
+}
+
+#endif  // defined(V8_TARGET_ARCH_RISCV64)
 
 }  // namespace internal
 }  // namespace v8

--- a/src/codegen/riscv64/assembler-riscv64.cc
+++ b/src/codegen/riscv64/assembler-riscv64.cc
@@ -409,13 +409,22 @@ static inline Instr SetBranchOffset(int32_t pos, int32_t target_pos,
 }
 
 static inline Instr SetLdOffset(int32_t offset, Instr instr) {
+  DCHECK(Assembler::IsLd(instr));
   DCHECK(is_int12(offset));
   instr &= ~kImm12Mask;
   int32_t imm12 = offset << kImm12Shift;
   return instr | (imm12 & kImm12Mask);
 }
 
+static inline Instr SetAuipcOffset(int32_t offset, Instr instr) {
+  DCHECK(Assembler::IsAuipc(instr));
+  DCHECK(is_int20(offset));
+  instr = (instr & ~kImm31_12Mask) | ((offset & kImm19_0Mask) << 12);
+  return instr;
+}
+
 static inline Instr SetJalOffset(int32_t pos, int32_t target_pos, Instr instr) {
+  DCHECK(Assembler::IsJal(instr));
   int32_t imm = target_pos - pos;
   DCHECK_EQ(imm & 1, 0);
   DCHECK(is_intn(imm, Assembler::kJumpOffsetBits));
@@ -461,8 +470,6 @@ void Assembler::target_at_put(int pos, int target_pos, bool is_internal) {
     int32_t Hi20 = (((int32_t)offset + 0x800) >> 12);
     int32_t Lo12 = (int32_t)offset << 20 >> 20;
 
-    const int kImm31_12Mask = ((1 << 20) - 1) << 12;
-    const int kImm19_0Mask = ((1 << 20) - 1);
     instr_auipc = (instr_auipc & ~kImm31_12Mask) |
                   ((Hi20 & kImm19_0Mask) << 12);
     instr_at_put(pos, instr_auipc);
@@ -621,11 +628,17 @@ int Assembler::BrachlongOffset(Instr auipc, Instr jalr) {
 }
 
 int Assembler::LdOffset(Instr instr) {
+  DCHECK(IsLd(instr));
   int32_t imm12 = (instr & kImm12Mask) >> 20;
   imm12 = imm12 << 12 >> 12;
   return imm12;
 }
 
+int Assembler::AuipcOffset(Instr instr){
+   DCHECK(IsAuipc(instr));
+   int32_t imm20 = instr & kImm20Mask;
+   return imm20;
+}
 // We have to use a temporary register for things that can be relocated even
 // if they can be encoded in RISC-V's 12 bits of immediate-offset instruction
 // space.  There is no guarantee that the relocated location can be similarly
@@ -1071,13 +1084,11 @@ void Assembler::auipc(Register rd, int32_t imm20) {
 // Jumps
 
 void Assembler::jal(Register rd, int32_t imm21) {
-  BlockTrampolinePoolScope block_trampoline_pool(this);
   GenInstrJ(JAL, rd, imm21);
   BlockTrampolinePoolFor(1);
 }
 
 void Assembler::jalr(Register rd, Register rs1, int16_t imm12) {
-  BlockTrampolinePoolScope block_trampoline_pool(this);
   GenInstrI(0b000, JALR, rd, rs1, imm12);
   BlockTrampolinePoolFor(1);
 }
@@ -2230,14 +2241,17 @@ void Assembler::CheckTrampolinePool() {
   return;
 }
 
-  void Assembler::set_target_address_at(
-      Address pc, Address constant_pool, Address target,
+void Assembler::set_target_address_at(Address pc, Address constant_pool,
+                                      Address target,
       ICacheFlushMode icache_flush_mode) {
     Instr* instr = reinterpret_cast<Instr*>(pc);
-    if (IsLd(*instr)) {
-      Memory<Address>(LdOffset(*instr) + pc - kInstrSize) = target;
+  if (IsAuipc(*instr)) {
+    DCHECK(IsLd(*reinterpret_cast<Instr*>(pc + 4)));
+    int32_t Hi20 = AuipcOffset(*instr);
+    int32_t Lo12 = LdOffset(*reinterpret_cast<Instr*>(pc + 4));
+    Memory<Address>(pc + Hi20 + Lo12) = target;
       if (icache_flush_mode != SKIP_ICACHE_FLUSH) {
-        FlushInstructionCache(LdOffset(*instr) + pc, 2 * kInstrSize);
+      FlushInstructionCache(pc + Hi20 + Lo12, 2 * kInstrSize);
       }
     } else {
       set_target_address_at(pc, target, icache_flush_mode);
@@ -2246,8 +2260,11 @@ void Assembler::CheckTrampolinePool() {
 
 Address Assembler::target_address_at(Address pc, Address constant_pool) {
   Instr* instr = reinterpret_cast<Instr*>(pc);
-  if (IsLd(*instr)) {
-    return Memory<Address>(LdOffset(*instr) + pc - kInstrSize);
+  if (IsAuipc(*instr)) {
+    DCHECK(IsLd(*reinterpret_cast<Instr*>(pc + 4)));
+    int32_t Hi20 = AuipcOffset(*instr);
+    int32_t Lo12 = LdOffset(*reinterpret_cast<Instr*>(pc + 4));
+    return Memory<Address>(pc + Hi20 + Lo12);
   } else {
     return target_address_at(pc);
   }
@@ -2444,15 +2461,21 @@ int ConstantPool::PrologueSize(Jump require_jump) const {
 void ConstantPool::SetLoadOffsetToConstPoolEntry(int load_offset,
                                                  Instruction* entry_offset,
                                                  const ConstantPoolKey& key) {
-  Instr instr = assm_->instr_at(load_offset);
+  Instr instr_auipc = assm_->instr_at(load_offset);
+  Instr instr_ld = assm_->instr_at(load_offset + 4);
   // Instruction to patch must be 'ld t3, t3, offset' with offset == kInstrSize.
-  DCHECK(assm_->IsLd(instr));
-  int32_t offset = assm_->LdOffset(instr);
-  DCHECK_EQ(offset, kInstrSize);
-  int32_t distance = static_cast<int32_t>(reinterpret_cast<Address>(entry_offset) -
-                     reinterpret_cast<Address>(assm_->toAddress(load_offset) - kInstrSize));
-  CHECK(is_int12(distance));
-  assm_->instr_at_put(load_offset, SetLdOffset(distance, instr));
+  DCHECK(assm_->IsAuipc(instr_auipc));
+  DCHECK(assm_->IsLd(instr_ld));
+  DCHECK_EQ(assm_->LdOffset(instr_ld), 0);
+  DCHECK_EQ(assm_->AuipcOffset(instr_auipc), 0);
+  int32_t distance = static_cast<int32_t>(
+      reinterpret_cast<Address>(entry_offset) -
+      reinterpret_cast<Address>(assm_->toAddress(load_offset)));
+  int32_t Hi20 = (((int32_t)distance + 0x800) >> 12);
+  int32_t Lo12 = (int32_t)distance << 20 >> 20;
+  CHECK(is_int32(distance));
+  assm_->instr_at_put(load_offset, SetAuipcOffset(Hi20, instr_auipc));
+  assm_->instr_at_put(load_offset + 4, SetLdOffset(Lo12, instr_ld));
 }
 
 void ConstantPool::Check(Emission force_emit, Jump require_jump,
@@ -2478,8 +2501,7 @@ void ConstantPool::Check(Emission force_emit, Jump require_jump,
     // Check that the code buffer is large enough before emitting the constant
     // pool (this includes the gap to the relocation information).
     int needed_space = worst_case_size + assm_->kGap;
-    int64_t space = assm_->buffer_space();
-    while (space <= needed_space) {
+    while (assm_->buffer_space() <= needed_space) {
       assm_->GrowBuffer();
     }
 
@@ -2491,17 +2513,17 @@ void ConstantPool::Check(Emission force_emit, Jump require_jump,
 }
 
 // Pool entries are accessed with pc relative load therefore this cannot be more
-// than 4 * KB. Since constant pool emission checks are interval based, and we
-// want to keep entries close to the code, we try to emit every 1KB.
-const size_t ConstantPool::kMaxDistToPool32 = 4 * KB;
-const size_t ConstantPool::kMaxDistToPool64 = 4 * KB;
+// than 1 * MB. Since constant pool emission checks are interval based, and we
+// want to keep entries close to the code, we try to emit every 64KB.
+const size_t ConstantPool::kMaxDistToPool32 = 1 * MB;
+const size_t ConstantPool::kMaxDistToPool64 = 1 * MB;
 const size_t ConstantPool::kCheckInterval = 128 * kInstrSize;
-const size_t ConstantPool::kApproxDistToPool32 = 1 * KB;
+const size_t ConstantPool::kApproxDistToPool32 = 64 * KB;
 const size_t ConstantPool::kApproxDistToPool64 = kApproxDistToPool32;
 
-const size_t ConstantPool::kOpportunityDistToPool32 = 1 * KB;
-const size_t ConstantPool::kOpportunityDistToPool64 = 1 * KB;
-const size_t ConstantPool::kApproxMaxEntryCount = 64;
+const size_t ConstantPool::kOpportunityDistToPool32 = 64 * KB;
+const size_t ConstantPool::kOpportunityDistToPool64 = 64 * KB;
+const size_t ConstantPool::kApproxMaxEntryCount = 512;
 
 }  // namespace internal
 }  // namespace v8

--- a/src/codegen/riscv64/constants-riscv64.h
+++ b/src/codegen/riscv64/constants-riscv64.h
@@ -214,6 +214,8 @@ const int kRdFieldMask = ((1 << kRdBits) - 1) << kRdShift;
 const int kBImm12Mask = kFunct7Mask | kRdFieldMask;
 const int kImm20Mask = ((1 << kImm20Bits) - 1) << kImm20Shift;
 const int kImm12Mask = ((1 << kImm12Bits) - 1) << kImm12Shift;
+const int kImm31_12Mask = ((1 << 20) - 1) << 12;
+const int kImm19_0Mask = ((1 << 20) - 1);
 
 // RISCV CSR related bit mask and shift
 const int kFcsrFlagsBits = 5;

--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -2892,6 +2892,7 @@ void TurboAssembler::Jump(Register target, Condition cond, Register rs,
   BlockTrampolinePoolScope block_trampoline_pool(this);
   if (cond == cc_always) {
     jr(target);
+    EmitConstPoolWithJumpIfNeeded();
   } else {
     BRANCH_ARGS_CHECK(cond, rs, rt);
     Branch(kInstrSize * 2, NegateCondition(cond), rs, rt);
@@ -3086,6 +3087,9 @@ void TurboAssembler::StoreReturnAddressAndCall(Register target) {
 
 void TurboAssembler::Ret(Condition cond, Register rs, const Operand& rt) {
   Jump(ra, cond, rs, rt);
+  if(cond == al){
+    ForceConstantPoolEmissionWithoutJump();
+  }
 }
 
 void TurboAssembler::BranchLong(Label* L) {
@@ -3098,6 +3102,7 @@ void TurboAssembler::BranchLong(Label* L) {
   int32_t Lo12 = (int32_t)imm64 << 20 >> 20;
   auipc(t5, Hi20);  // Read PC + Hi20 into t5.
   jr(t5, Lo12);     // jump PC + Hi20 + Lo12
+  EmitConstPoolWithJumpIfNeeded();
 }
 
 void TurboAssembler::BranchAndLinkLong(Label* L) {
@@ -3597,11 +3602,11 @@ void MacroAssembler::JumpToExternalReference(const ExternalReference& builtin,
 
 void MacroAssembler::JumpToInstructionStream(Address entry) {
   //Ld a Address from a constant pool.
-  auipc(kOffHeapTrampolineRegister, 0);
   //Record a value into constant pool.
   RecordEntry(entry, RelocInfo::OFF_HEAP_TARGET);
   RecordRelocInfo(RelocInfo::OFF_HEAP_TARGET, entry);
-  ld(kOffHeapTrampolineRegister, kOffHeapTrampolineRegister, kInstrSize);
+  auipc(kOffHeapTrampolineRegister, 0);
+  ld(kOffHeapTrampolineRegister, kOffHeapTrampolineRegister, 0);
   Jump(kOffHeapTrampolineRegister);
 }
 


### PR DESCRIPTION
Split constant pool from ARM64.
And add range to load a constant by auipc+ld.
BlockTrampolinePoolScope does't automatically emit a constantpool.