### PR TITLE
Skip LoggingTest.SourceLocation when is_clang is false.

### DIFF
--- a/test/unittests/unittests.status
+++ b/test/unittests/unittests.status
@@ -57,5 +57,7 @@
 ['variant == stress_snapshot', {
   '*': [SKIP],  # only relevant for mjsunit tests.
 }],
-
+['is_clang == False and arch == riscv64',{
+  'LoggingTest.SourceLocation':[SKIP] #issue-174
+}],
 ]


### PR DESCRIPTION
fix #174 