### PR TITLE
Refactor test-macro-assembler-riscv64 and test-assembler-riscv64:

### DIFF
--- a/test/cctest/BUILD.gn
+++ b/test/cctest/BUILD.gn
@@ -392,6 +392,7 @@ v8_source_set("cctest_sources") {
     ]
   } else if (v8_current_cpu == "riscv64") {
     sources += [  ### gcmole(arch:riscv64) ###
+      "test-helper-riscv.cc",
       "test-assembler-riscv64.cc",
       "test-simple-riscv64.cc",
       "test-disasm-riscv64.cc",
@@ -399,6 +400,7 @@ v8_source_set("cctest_sources") {
     ]
   }  else if (v8_current_cpu == "riscv") {
     sources += [  ### gcmole(arch:riscv) ###
+      "test-helper-riscv.cc",
       "test-assembler-riscv.cc",
       "test-simple-riscv.cc",
       "test-disasm-riscv.cc",

--- a/test/cctest/test-helper-riscv.cc
+++ b/test/cctest/test-helper-riscv.cc
@@ -1,0 +1,49 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "test/cctest/test-helper-riscv.h"
+
+#include "src/codegen/macro-assembler.h"
+#include "src/execution/isolate-inl.h"
+#include "src/init/v8.h"
+#include "test/cctest/cctest.h"
+
+namespace v8 {
+namespace internal {
+
+int64_t GenAndRunTest(Func test_generator) {
+  Isolate* isolate = CcTest::i_isolate();
+  HandleScope scope(isolate);
+
+  MacroAssembler assm(isolate, v8::internal::CodeObjectRequired::kYes);
+  test_generator(assm);
+  assm.jr(ra);
+
+  CodeDesc desc;
+  assm.GetCode(isolate, &desc);
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  auto f = GeneratedCode<int64_t()>::FromCode(*code);
+  return f.Call();
+}
+
+Handle<Code> AssembleCodeImpl(Func assemble) {
+  Isolate* isolate = CcTest::i_isolate();
+  MacroAssembler assm(isolate, CodeObjectRequired::kYes);
+
+  assemble(assm);
+  assm.jr(ra);
+
+  CodeDesc desc;
+  assm.GetCode(isolate, &desc);
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+  if (FLAG_print_code) {
+    code->Print();
+  }
+  return code;
+}
+
+}  // namespace internal
+}  // namespace v8

--- a/test/cctest/test-helper-riscv.h
+++ b/test/cctest/test-helper-riscv.h
@@ -1,0 +1,228 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_CCTEST_TEST_HELPER_RISCV_H_
+#define V8_CCTEST_TEST_HELPER_RISCV_H_
+
+#include "src/codegen/assembler-inl.h"
+#include "src/codegen/macro-assembler.h"
+#include "src/diagnostics/disassembler.h"
+#include "src/execution/simulator.h"
+#include "src/heap/factory.h"
+#include "src/init/v8.h"
+#include "src/utils/utils.h"
+#include "test/cctest/cctest.h"
+
+#define PRINT_RES(res, expected_res, in_hex)                         \
+  if (in_hex) std::cout << "[hex-form]" << std::hex;                 \
+  std::cout << "res = " << (res) << " expected = " << (expected_res) \
+            << std::endl;
+
+namespace v8 {
+namespace internal {
+
+using Func = std::function<void(MacroAssembler&)>;
+
+int64_t GenAndRunTest(Func test_generator);
+
+// f.Call(...) interface is implemented as varargs in V8. For varargs,
+// floating-point arguments and return values are passed in GPRs, therefore
+// the special handling to reinterpret floating-point as integer values when
+// passed in and out of f.Call()
+template <typename OUTPUT_T, typename INPUT_T>
+OUTPUT_T GenAndRunTest(INPUT_T input0, Func test_generator) {
+  DCHECK((sizeof(INPUT_T) == 4 || sizeof(INPUT_T) == 8));
+
+  Isolate* isolate = CcTest::i_isolate();
+  HandleScope scope(isolate);
+
+  MacroAssembler assm(isolate, v8::internal::CodeObjectRequired::kYes);
+
+  // handle floating-point parameters
+  if (std::is_same<float, INPUT_T>::value) {
+    assm.fmv_w_x(fa0, a0);
+  } else if (std::is_same<double, INPUT_T>::value) {
+    assm.fmv_d_x(fa0, a0);
+  }
+
+  test_generator(assm);
+
+  // handle floating-point result
+  if (std::is_same<float, OUTPUT_T>::value) {
+    assm.fmv_x_w(a0, fa0);
+  } else if (std::is_same<double, OUTPUT_T>::value) {
+    assm.fmv_x_d(a0, fa0);
+  }
+  assm.jr(ra);
+
+  CodeDesc desc;
+  assm.GetCode(isolate, &desc);
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+
+  using OINT_T = typename std::conditional<
+      std::is_integral<OUTPUT_T>::value, OUTPUT_T,
+      typename std::conditional<sizeof(OUTPUT_T) == 4, int32_t,
+                                int64_t>::type>::type;
+  using IINT_T = typename std::conditional<
+      std::is_integral<INPUT_T>::value, INPUT_T,
+      typename std::conditional<sizeof(INPUT_T) == 4, int32_t,
+                                int64_t>::type>::type;
+
+  auto f = GeneratedCode<OINT_T(IINT_T)>::FromCode(*code);
+
+  auto res = f.Call(bit_cast<IINT_T>(input0));
+  return bit_cast<OUTPUT_T>(res);
+}
+
+template <typename OUTPUT_T, typename INPUT_T>
+OUTPUT_T GenAndRunTest(INPUT_T input0, INPUT_T input1, Func test_generator) {
+  DCHECK((sizeof(INPUT_T) == 4 || sizeof(INPUT_T) == 8));
+
+  Isolate* isolate = CcTest::i_isolate();
+  HandleScope scope(isolate);
+
+  MacroAssembler assm(isolate, v8::internal::CodeObjectRequired::kYes);
+
+  // handle floating-point parameters
+  if (std::is_same<float, INPUT_T>::value) {
+    assm.fmv_w_x(fa0, a0);
+    assm.fmv_w_x(fa1, a1);
+  } else if (std::is_same<double, INPUT_T>::value) {
+    assm.fmv_d_x(fa0, a0);
+    assm.fmv_d_x(fa1, a1);
+  }
+
+  test_generator(assm);
+
+  // handle floating-point result
+  if (std::is_same<float, OUTPUT_T>::value) {
+    assm.fmv_x_w(a0, fa0);
+  } else if (std::is_same<double, OUTPUT_T>::value) {
+    assm.fmv_x_d(a0, fa0);
+  }
+  assm.jr(ra);
+
+  CodeDesc desc;
+  assm.GetCode(isolate, &desc);
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+
+  using OINT_T = typename std::conditional<
+      std::is_integral<OUTPUT_T>::value, OUTPUT_T,
+      typename std::conditional<sizeof(OUTPUT_T) == 4, int32_t,
+                                int64_t>::type>::type;
+  using IINT_T = typename std::conditional<
+      std::is_integral<INPUT_T>::value, INPUT_T,
+      typename std::conditional<sizeof(INPUT_T) == 4, int32_t,
+                                int64_t>::type>::type;
+  auto f = GeneratedCode<OINT_T(IINT_T, IINT_T)>::FromCode(*code);
+
+  auto res = f.Call(bit_cast<IINT_T>(input0), bit_cast<IINT_T>(input1));
+  return bit_cast<OUTPUT_T>(res);
+}
+
+template <typename OUTPUT_T, typename INPUT_T>
+OUTPUT_T GenAndRunTest(INPUT_T input0, INPUT_T input1, INPUT_T input2,
+                       Func test_generator) {
+  DCHECK((sizeof(INPUT_T) == 4 || sizeof(INPUT_T) == 8));
+  DCHECK(sizeof(OUTPUT_T) == sizeof(INPUT_T));
+
+  Isolate* isolate = CcTest::i_isolate();
+  HandleScope scope(isolate);
+
+  MacroAssembler assm(isolate, v8::internal::CodeObjectRequired::kYes);
+
+  // handle floating-point parameters
+  if (std::is_same<float, INPUT_T>::value) {
+    assm.fmv_w_x(fa0, a0);
+    assm.fmv_w_x(fa1, a1);
+    assm.fmv_w_x(fa2, a2);
+  } else if (std::is_same<double, INPUT_T>::value) {
+    assm.fmv_d_x(fa0, a0);
+    assm.fmv_d_x(fa1, a1);
+    assm.fmv_d_x(fa2, a2);
+  }
+
+  test_generator(assm);
+
+  // handle floating-point result
+  if (std::is_same<float, OUTPUT_T>::value) {
+    assm.fmv_x_w(a0, fa0);
+  } else if (std::is_same<double, OUTPUT_T>::value) {
+    assm.fmv_x_d(a0, fa0);
+  }
+  assm.jr(ra);
+
+  CodeDesc desc;
+  assm.GetCode(isolate, &desc);
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+
+  using OINT_T = typename std::conditional<
+      std::is_integral<OUTPUT_T>::value, OUTPUT_T,
+      typename std::conditional<sizeof(OUTPUT_T) == 4, int32_t,
+                                int64_t>::type>::type;
+  using IINT_T = typename std::conditional<
+      std::is_integral<INPUT_T>::value, INPUT_T,
+      typename std::conditional<sizeof(INPUT_T) == 4, int32_t,
+                                int64_t>::type>::type;
+  auto f = GeneratedCode<OINT_T(IINT_T, IINT_T, IINT_T)>::FromCode(*code);
+
+  auto res = f.Call(bit_cast<IINT_T>(input0), bit_cast<IINT_T>(input1),
+                    bit_cast<IINT_T>(input2));
+  return bit_cast<OUTPUT_T>(res);
+}
+
+template <typename T>
+void GenAndRunTestForLoadStore(T value, Func test_generator) {
+  DCHECK(sizeof(T) == 4 || sizeof(T) == 8);
+
+  Isolate* isolate = CcTest::i_isolate();
+  HandleScope scope(isolate);
+
+  MacroAssembler assm(isolate, v8::internal::CodeObjectRequired::kYes);
+
+  if (std::is_same<float, T>::value) {
+    assm.fmv_w_x(fa0, a1);
+  } else if (std::is_same<double, T>::value) {
+    assm.fmv_d_x(fa0, a1);
+  }
+
+  test_generator(assm);
+
+  if (std::is_same<float, T>::value) {
+    assm.fmv_x_w(a0, fa0);
+  } else if (std::is_same<double, T>::value) {
+    assm.fmv_x_d(a0, fa0);
+  }
+  assm.jr(ra);
+
+  CodeDesc desc;
+  assm.GetCode(isolate, &desc);
+  Handle<Code> code =
+      Factory::CodeBuilder(isolate, desc, CodeKind::STUB).Build();
+
+  using INT_T = typename std::conditional<
+      std::is_integral<T>::value, T,
+      typename std::conditional<sizeof(T) == 4, int32_t, int64_t>::type>::type;
+
+  auto f = GeneratedCode<INT_T(void* base, INT_T val)>::FromCode(*code);
+
+  int64_t tmp = 0;
+  auto res = f.Call(&tmp, bit_cast<INT_T>(value));
+  CHECK_EQ(bit_cast<T>(res), value);
+}
+
+Handle<Code> AssembleCodeImpl(Func assemble);
+
+template <typename Signature>
+GeneratedCode<Signature> AssembleCode(Func assemble) {
+  return GeneratedCode<Signature>::FromCode(*AssembleCodeImpl(assemble));
+}
+
+}  // namespace internal
+}  // namespace v8
+
+#endif  // V8_CCTEST_TEST_HELPER_RISCV_H_


### PR DESCRIPTION
- Share GenAndRunTest across test-macro-assembler and test-assembler tests
  so that redundant Run_xxx helper functions are removed
- Incorporated the fix in #222 w/o duplicating GenAndRunTest
- Use FOR_INT64_INPUTS defined in value-helper.h instead of defining our
  own set of corner-case values
- Cleaned-up SetParam/GetParam and use bit_cast<T> to convert between
  int and floating-point types
- Use AssembleCode to remove some boilerplate codes to build CodeObject
- Remove redundant nop (legacy of MIPS delay slot)