### PR TITLE
Add RVC instructions: c.nop, c.ebreak, c.add, c.addi

### DIFF
--- a/src/codegen/riscv64/assembler-riscv64-inl.h
+++ b/src/codegen/riscv64/assembler-riscv64-inl.h
@@ -239,6 +239,13 @@ void Assembler::emit(Instr x) {
   EmitHelper(x);
 }
 
+void Assembler::emit(ShortInstr x) {
+  if (!is_buffer_growth_blocked()) {
+    CheckBuffer();
+  }
+  EmitHelper(x);
+}
+
 void Assembler::emit(uint64_t data) {
   if (!is_buffer_growth_blocked()) CheckBuffer();
   EmitHelper(data);

--- a/src/codegen/riscv64/assembler-riscv64.h
+++ b/src/codegen/riscv64/assembler-riscv64.h
@@ -578,6 +578,12 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   void fcvt_d_lu(FPURegister rd, Register rs1, RoundingMode frm = RNE);
   void fmv_d_x(FPURegister rd, Register rs1);
 
+  // RV64C Standard Extension
+  void c_nop();
+  void c_addi(Register rd, int8_t imm6);
+  void c_ebreak();
+  void c_add(Register rd, Register rs2);
+
   // Privileged
   void uret();
   void sret();
@@ -964,6 +970,7 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   inline void CheckBuffer();
   void GrowBuffer();
   inline void emit(Instr x);
+  inline void emit(ShortInstr x);
   inline void emit(uint64_t x);
   template <typename T>
   inline void EmitHelper(T x);
@@ -1012,6 +1019,9 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
                  int16_t imm12);
   void GenInstrU(Opcode opcode, Register rd, int32_t imm20);
   void GenInstrJ(Opcode opcode, Register rd, int32_t imm20);
+  void GenInstrCR(uint8_t funct4, Opcode opcode, Register rd, Register rs2);
+  void GenInstrCI(uint8_t funct3, Opcode opcode, Register rd, int8_t imm6);
+  void GenInstrCIU(uint8_t funct3, Opcode opcode, Register rd, uint8_t uimm6);
 
   // ----- Instruction class templates match those in LLVM's RISCVInstrInfo.td
   void GenInstrBranchCC_rri(uint8_t funct3, Register rs1, Register rs2,

--- a/src/execution/riscv64/simulator-riscv64.h
+++ b/src/execution/riscv64/simulator-riscv64.h
@@ -469,11 +469,17 @@ class Simulator : public SimulatorBase {
   inline double drs3() const { return get_fpu_register_double(rs3_reg()); }
   inline int32_t rd_reg() const { return instr_.RdValue(); }
   inline int32_t frd_reg() const { return instr_.RdValue(); }
+  inline int32_t rvc_rs1_reg() const { return instr_.RvcRs1Value(); }
+  inline int64_t rvc_rs1() const { return get_register(rvc_rs1_reg()); }
+  inline int32_t rvc_rs2_reg() const { return instr_.RvcRs2Value(); }
+  inline int64_t rvc_rs2() const { return get_register(rvc_rs2_reg()); }
+  inline int32_t rvc_rd_reg() const { return instr_.RvcRdValue(); }
   inline int16_t boffset() const { return instr_.BranchOffset(); }
   inline int16_t imm12() const { return instr_.Imm12Value(); }
   inline int32_t imm20J() const { return instr_.Imm20JValue(); }
   inline int32_t imm5CSR() const { return instr_.Rs1Value(); }
   inline int16_t csr_reg() const { return instr_.CsrValue(); }
+  inline int16_t rvc_imm6() const { return instr_.RvcImm6Value(); }
 
   inline void set_rd(int64_t value, bool trace = true) {
     set_register(rd_reg(), value);
@@ -486,6 +492,10 @@ class Simulator : public SimulatorBase {
   inline void set_drd(double value, bool trace = true) {
     set_fpu_register_double(rd_reg(), value);
     if (trace) TraceRegWr(get_fpu_register(rd_reg()), DOUBLE);
+  }
+  inline void set_rvc_rd(int64_t value, bool trace = true) {
+    set_register(rvc_rd_reg(), value);
+    if (trace) TraceRegWr(get_register(rvc_rd_reg()), DWORD);
   }
   inline int16_t shamt() const { return (imm12() & 0x3F); }
   inline int16_t shamt32() const { return (imm12() & 0x1F); }
@@ -571,6 +581,8 @@ class Simulator : public SimulatorBase {
   void DecodeRVBType();
   void DecodeRVUType();
   void DecodeRVJType();
+  void DecodeCRType();
+  void DecodeCIType();
 
   // Used for breakpoints and traps.
   void SoftwareInterrupt();

--- a/test/cctest/test-assembler-riscv64.cc
+++ b/test/cctest/test-assembler-riscv64.cc
@@ -1149,6 +1149,35 @@ TEST(NAN_BOX) {
   CHECK_EQ((uint64_t)bit_cast<uint32_t>(t.a), t.res);
 }
 
+TEST(RVC_CI) {
+  // Test RV64C extension CI type instructions.
+  CcTest::InitializeVM();
+
+  // Test c.addi
+  {
+    auto fn = [](MacroAssembler& assm) { __ c_addi(a0, -15); };
+    auto res = GenAndRunTest<int64_t>(LARGE_INT_EXCEED_32_BIT, fn);
+    CHECK_EQ(LARGE_INT_EXCEED_32_BIT - 15, res);
+  }
+
+}
+
+TEST(RVC_CR) {
+  // Test RV64C extension CR type instructions.
+  CcTest::InitializeVM();
+
+  // Test c.add
+  {
+    auto fn = [](MacroAssembler& assm) { 
+      __ RV_li(a1, MIN_VAL_IMM12);
+      __ c_add(a0, a1); 
+    };
+    auto res = GenAndRunTest<int64_t>(LARGE_INT_EXCEED_32_BIT, fn);
+    CHECK_EQ(LARGE_INT_EXCEED_32_BIT + MIN_VAL_IMM12, res);
+  }
+
+}
+
 TEST(TARGET_ADDR) {
   CcTest::InitializeVM();
   Isolate* isolate = CcTest::i_isolate();

--- a/test/cctest/test-disasm-riscv64.cc
+++ b/test/cctest/test-disasm-riscv64.cc
@@ -459,6 +459,17 @@ TEST(PSEUDO) {
   VERIFY_RUN();
 }
 
+TEST(RV64C) {
+  SET_UP();
+
+  COMPARE(c_nop(), "00000001       nop");
+  COMPARE(c_addi(s3, -25), "0000199d       addi      s3, s3, -25");
+  COMPARE(c_ebreak(), "00009002       ebreak");
+  COMPARE(c_add(s6, t0), "00009b16       add       s6, s6, t0");
+
+  VERIFY_RUN();
+}
+
 /*
 TEST(Previleged) {
   SET_UP();


### PR DESCRIPTION
I also want get some advice about C extension in assembler and disasm.

----

In assembler, C-ext instruction generation keeps consistent w/ expanded 32-bit instruction. 

e.g.
```
void addi(Register rd, Register rs1, int16_t imm12);

void c_addi(Register rd, Register rs1, int16_t imm6);
```

It is convenient to write unit test, but one of parameter is redundant.

Should we use compressed function parameters, like

```
void c_addi(Register rd, int16_t imm);
```

Or is it better to provide both functions?

----

In disasm, which print format is better for readability? 

The one without redundancy. 
```
0000199d       c.addi    s3, -25
```

Or the one keeps consistent w/ expanded 32-bit instruction.

```
0000199d       c.addi    s3, s3, -25
```
