### PR TITLE
Disacard scratch reg in ULoadF/UStoref

### DIFF
--- a/src/codegen/riscv64/macro-assembler-riscv64.h
+++ b/src/codegen/riscv64/macro-assembler-riscv64.h
@@ -556,11 +556,9 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
                             Register scratch_other = no_reg);
 
   template <int NBYTES>
-  void UnalignedFLoadHelper(FPURegister frd, const MemOperand& rs,
-                            Register scratch);
+  void UnalignedFLoadHelper(FPURegister frd, const MemOperand& rs);
   template <int NBYTES>
-  void UnalignedFStoreHelper(FPURegister frd, const MemOperand& rs,
-                             Register scratch);
+  void UnalignedFStoreHelper(FPURegister frd, const MemOperand& rs);
 
   template <typename Reg_T, typename Func>
   void AlignedLoadHelper(Reg_T target, const MemOperand& rs, Func generator);
@@ -584,11 +582,11 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   void Uld(Register rd, const MemOperand& rs);
   void Usd(Register rd, const MemOperand& rs);
 
-  void ULoadFloat(FPURegister fd, const MemOperand& rs, Register scratch);
-  void UStoreFloat(FPURegister fd, const MemOperand& rs, Register scratch);
+  void ULoadFloat(FPURegister fd, const MemOperand& rs);
+  void UStoreFloat(FPURegister fd, const MemOperand& rs);
 
-  void ULoadDouble(FPURegister fd, const MemOperand& rs, Register scratch);
-  void UStoreDouble(FPURegister fd, const MemOperand& rs, Register scratch);
+  void ULoadDouble(FPURegister fd, const MemOperand& rs);
+  void UStoreDouble(FPURegister fd, const MemOperand& rs);
 
   void Lb(Register rd, const MemOperand& rs);
   void Lbu(Register rd, const MemOperand& rs);

--- a/src/compiler/backend/riscv64/code-generator-riscv64.cc
+++ b/src/compiler/backend/riscv64/code-generator-riscv64.cc
@@ -1605,7 +1605,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       break;
     }
     case kRiscvULoadFloat: {
-      __ ULoadFloat(i.OutputSingleRegister(), i.MemoryOperand(), kScratchReg);
+      __ ULoadFloat(i.OutputSingleRegister(), i.MemoryOperand());
       break;
     }
     case kRiscvStoreFloat: {
@@ -1625,14 +1625,14 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       if (ft == kDoubleRegZero && !__ IsSingleZeroRegSet()) {
         __ LoadFPRImmediate(kDoubleRegZero, 0.0f);
       }
-      __ UStoreFloat(ft, operand, kScratchReg);
+      __ UStoreFloat(ft, operand);
       break;
     }
     case kRiscvLoadDouble:
       __ LoadDouble(i.OutputDoubleRegister(), i.MemoryOperand());
       break;
     case kRiscvULoadDouble:
-      __ ULoadDouble(i.OutputDoubleRegister(), i.MemoryOperand(), kScratchReg);
+      __ ULoadDouble(i.OutputDoubleRegister(), i.MemoryOperand());
       break;
     case kRiscvStoreDouble: {
       FPURegister ft = i.InputOrZeroDoubleRegister(2);
@@ -1647,7 +1647,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       if (ft == kDoubleRegZero && !__ IsDoubleZeroRegSet()) {
         __ LoadFPRImmediate(kDoubleRegZero, 0.0);
       }
-      __ UStoreDouble(ft, i.MemoryOperand(), kScratchReg);
+      __ UStoreDouble(ft, i.MemoryOperand());
       break;
     }
     case kRiscvSync: {

--- a/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
+++ b/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
@@ -77,10 +77,10 @@ inline void Store(LiftoffAssembler* assm, Register base, int32_t offset,
       assm->Usd(src.gp(), dst);
       break;
     case ValueType::kF32:
-      assm->UStoreFloat(src.fp(), dst, t5);
+      assm->UStoreFloat(src.fp(), dst);
       break;
     case ValueType::kF64:
-      assm->UStoreDouble(src.fp(), dst, t5);
+      assm->UStoreDouble(src.fp(), dst);
       break;
     default:
       UNREACHABLE();
@@ -394,10 +394,10 @@ void LiftoffAssembler::Load(LiftoffRegister dst, Register src_addr,
       TurboAssembler::Uld(dst.gp(), src_op);
       break;
     case LoadType::kF32Load:
-      TurboAssembler::ULoadFloat(dst.fp(), src_op, t5);
+      TurboAssembler::ULoadFloat(dst.fp(), src_op);
       break;
     case LoadType::kF64Load:
-      TurboAssembler::ULoadDouble(dst.fp(), src_op, t5);
+      TurboAssembler::ULoadDouble(dst.fp(), src_op);
       break;
     default:
       UNREACHABLE();
@@ -459,10 +459,10 @@ void LiftoffAssembler::Store(Register dst_addr, Register offset_reg,
       TurboAssembler::Usd(src.gp(), dst_op);
       break;
     case StoreType::kF32Store:
-      TurboAssembler::UStoreFloat(src.fp(), dst_op, t5);
+      TurboAssembler::UStoreFloat(src.fp(), dst_op);
       break;
     case StoreType::kF64Store:
-      TurboAssembler::UStoreDouble(src.fp(), dst_op, t5);
+      TurboAssembler::UStoreDouble(src.fp(), dst_op);
       break;
     default:
       UNREACHABLE();

--- a/test/cctest/test-macro-assembler-riscv64.cc
+++ b/test/cctest/test-macro-assembler-riscv64.cc
@@ -931,8 +931,8 @@ TEST(Uld) {
 }
 
 auto fn = [](MacroAssembler& masm, int32_t in_offset, int32_t out_offset) {
-  __ ULoadFloat(fa0, MemOperand(a0, in_offset), t0);
-  __ UStoreFloat(fa0, MemOperand(a0, out_offset), t0);
+  __ ULoadFloat(fa0, MemOperand(a0, in_offset));
+  __ UStoreFloat(fa0, MemOperand(a0, out_offset));
 };
 
 TEST(ULoadFloat) {
@@ -965,8 +965,8 @@ TEST(ULoadDouble) {
   char* buffer_middle = memory_buffer + (kBufferSize / 2);
 
   auto fn = [](MacroAssembler& masm, int32_t in_offset, int32_t out_offset) {
-    __ ULoadDouble(fa0, MemOperand(a0, in_offset), t0);
-    __ UStoreDouble(fa0, MemOperand(a0, out_offset), t0);
+    __ ULoadDouble(fa0, MemOperand(a0, in_offset));
+    __ UStoreDouble(fa0, MemOperand(a0, out_offset));
   };
 
   FOR_FLOAT64_INPUTS(i) {


### PR DESCRIPTION
- Becasue improve management of register t5 and t6, so we not need
  to use scratch paramter.
- fix #177