### PR TITLE
Add a tool to compare dynamic instruction count.

### DIFF
--- a/v8-riscv-tools/CountInstr.py
+++ b/v8-riscv-tools/CountInstr.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+# Copyright 2020 the V8 project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import sys
+import re
+import subprocess
+from collections import Counter
+import argparse
+
+
+def count(sub):
+    couts = []
+    for line in sub.stdout.readlines():
+        split = line.strip().decode('utf-8').split()
+        if("0x" not in split[0]):
+            continue
+        if(len(split) >= 4):
+            couts.append(split[2])
+    cout = Counter(couts).items()
+    cout = list(cout)
+    cout.sort(key=lambda x: x[1], reverse=True)
+    
+    return len(couts), cout
+
+def init():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('arch1', help="The path of an architecture executable d8.")
+    parser.add_argument('arch2', help="The path of an architecture executable d8.")
+    parser.add_argument('d8_object', nargs='+', help="The path to the target of d8 operation")
+    args, unknown = parser.parse_known_args()
+    return args, unknown
+
+
+def compare(arch1, arch2):
+    print("\t{}\t\t\t\t{}\n".format(arch1[2], arch2[2]))
+    print("total:\t{}\t\t\t\t{}\t\t\tmore: {:.2%}\n".format(
+        arch1[0], arch2[0], float(arch1[0] - arch2[0]) / arch2[0]))
+    print("\tinstr\tratio\tcount\t",end=' ')
+    print("\tinstr\tratio\tcount")
+    print("------------------------------------------------------------------------")
+    for n, v in zip(arch1[1], arch2[1]):
+        print("\t{}\t{:.2%}\t{}\t".format(n[0], float(n[1]) / arch1[0],n[1]),end=' ')
+        print("\t{}\t{:.2%}\t{}".format(v[0], float(v[1]) / arch2[0], n[1]))
+
+
+if __name__ == "__main__":
+    args, run_args = init()
+    run_args.append("--trace-sim")
+    run_args.insert(0, args.arch1)
+    run_args.extend(args.d8_object)
+    print(args,run_args)
+    sub = subprocess.Popen(
+        run_args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    risv = (count(sub))+tuple(["arch1"])
+
+    run_args[0] = args.arch2
+    sub = subprocess.Popen(
+        run_args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    mips64el = (count(sub))+tuple(["arhc2"])
+    compare(risv, mips64el)
+    pass


### PR DESCRIPTION
refer #195 

example:
```
yahan@2b971f1ad76e:~/v8-riscv64 $ python3 ./v8-riscv-tools/CountInstr.py ./out/riscv64.sim/d8 ./out/mips64el.debug/d8 --test test.js
        arch1                           arhc2

total:  3419                            3053                    more: 11.99%

        instr   ratio   count   instr   ratio   count
------------------------------------------------------------------------
        ld      16.00%  547             ld      17.79%  547
        addi    13.40%  458             daddiu  15.39%  458
        sd      12.64%  432             sd      14.05%  432
        mv      8.42%   288             mov     12.18%  288
        add     7.11%   243             dsll32  5.24%   243
        lui     5.94%   203             beq     3.18%   203
        slli    5.62%   192             and     2.69%   192
        li      4.36%   149             bltzal  2.39%   149
        andi    3.13%   107             ori     2.33%   107
        auipc   2.63%   90              jalr    2.23%   90
        jalr    2.49%   85              bne     2.19%   85
        beq     2.14%   73              break,  2.06%   73
        bne     1.67%   57              sltiu   1.87%   57
        seqz    1.61%   55              xor     1.77%   55
        xor     1.58%   54              andi    1.44%   54
        ori     1.29%   44              dsll    1.41%   44
        slliw   0.91%   31              daddu   1.38%   31
        sext.w  0.88%   30              slt     1.31%   30
        slt     0.82%   28              jr      1.05%   28
        lhu     0.56%   19              sll     1.02%   19
        and     0.56%   19              ext     0.98%   19
        or      0.47%   16              lhu     0.62%   16
        xori    0.47%   16              xori    0.52%   16
        lw      0.44%   15              lui     0.46%   15
        blt     0.41%   14              sltu    0.43%   14
        jr      0.38%   13              dsubu   0.39%   13
        fsd     0.35%   12              lbu     0.39%   12
        sub     0.35%   12              lw      0.36%   12
        lbu     0.35%   12              subu    0.36%   12
        srai    0.35%   12              or      0.36%   12
        fld     0.35%   12              lb      0.23%   12
        subw    0.32%   11              sw      0.23%   11
        j       0.29%   10              dsra32  0.23%   10
        bgeu    0.29%   10              sdc1    0.20%   10
        bge     0.29%   10              ldc1    0.20%   10
        lb      0.20%   7               lwu     0.16%   7
        sw      0.20%   7               bgez    0.16%   7
        ret     0.18%   6               sra     0.16%   6
        lwu     0.15%   5               nor     0.16%   5
        bltu    0.15%   5               bltz    0.16%   5
        not     0.15%   5               slti    0.07%   5
        addiw   0.09%   3               addu    0.07%   3
        fmv.d.x 0.03%   1               mtc1    0.03%   1
        sh      0.03%   1               mthc1   0.03%   1
```