### PR TITLE
Ensure that a failure is reported by CI

### DIFF
--- a/v8-riscv-tools/test-riscv.sh
+++ b/v8-riscv-tools/test-riscv.sh
@@ -1,29 +1,39 @@
 #!/bin/sh
 
+set -e
+
 SCRIPT=$(readlink -f "$0")
 DIR=$(dirname "$SCRIPT")
 
 while getopts ":o:" opt; do
     case "$opt" in
-    o)  outdir="$OPTARG"
+    o)
+        outdir="$OPTARG"
         ;;
-    \?)  echo "Unknown Parameter: $OPTARG" 1>&2
-	 exit 1
+    \?)
+        echo "Unknown Parameter: $OPTARG" 1>&2
+        exit 1
         ;;
-    :)  echo "Error: -o needs a parameter: $0 -o out/riscv64.sim" 1>&2
-	 exit 1
+    :)
+        echo "Error: -o needs a parameter: $0 -o out/riscv64.sim" 1>&2
+        exit 1
         ;;
     esac
 done
 
 [ -z "$outdir" ] && outdir=out/riscv64.sim
-shift $((OPTIND-1))
+shift $((OPTIND - 1))
 
-
-$DIR/../tools/run-tests.py -p verbose --report --outdir="$outdir" cctest
-$DIR/../tools/run-tests.py -p verbose --report --outdir="$outdir" unittests
-$DIR/../tools/run-tests.py -p verbose --report --outdir="$outdir" wasm-api-tests wasm-js
-$DIR/../tools/run-tests.py -p verbose --report --outdir="$outdir" mjsunit
-$DIR/../tools/run-tests.py -p verbose --report --outdir="$outdir" intl message debugger inspector mkgrokdump
-$DIR/../tools/run-tests.py -p verbose --report --outdir="$outdir" wasm-spec-tests
-$DIR/../tools/run-tests.py -p verbose --report --outdir="$outdir" fuzzer
+$DIR/../tools/run-tests.py -p verbose --report --outdir="$outdir" \
+    cctest \
+    unittests \
+    wasm-api-tests \
+    wasm-js \
+    mjsunit \
+    intl \
+    message \
+    debugger \
+    inspector \
+    mkgrokdump \
+    wasm-spec-tests \
+    fuzzer


### PR DESCRIPTION
Added `set -e` so that if any command fails, the script will fail and it
will be reported appropriately by the CI server. Also cleaned up the
script a bit and merged all of the tests into one command so that the
results are reported all together at the end.

Fixes #256