### PR TITLE
Fix cctest test-assembler-riscv64 for RVC_CIW and RVC_CI

### DIFF
--- a/test/cctest/test-assembler-riscv64.cc
+++ b/test/cctest/test-assembler-riscv64.cc
@@ -1220,9 +1220,11 @@ TEST(RVC_CI) {
   // Test c.addi16sp
   {
     auto fn = [](MacroAssembler& assm) { 
+      __ mv(t1, sp);
       __ mv(sp, a0);
       __ c_addi16sp(-432); 
       __ mv(a0, sp);
+      __ mv(sp, t1);
     };
     auto res = GenAndRunTest<int64_t>(66666, fn);
     CHECK_EQ(66666 - 432, res);
@@ -1258,8 +1260,10 @@ TEST(RVC_CIW) {
   // Test c.addi4spn
   {
     auto fn = [](MacroAssembler& assm) {
+      __ mv(t1, sp);
       __ mv(sp, a0);
       __ c_addi4spn(a0, 924);
+      __ mv(sp, t1);
     };
     auto res = GenAndRunTest<int64_t>(66666, fn);
     CHECK_EQ(66666 + 924, res);


### PR DESCRIPTION
fix #276 