### PR TITLE
Add a tool to collect statistics on C-ext convertible instructions

### DIFF
--- a/v8-riscv-tools/collect-convertible.py
+++ b/v8-riscv-tools/collect-convertible.py
@@ -1,0 +1,209 @@
+#!/usr/bin/python3
+
+# Copyright 2020 the V8 project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import sys
+import re
+import time
+from collections import Counter
+import argparse
+from prettytable import PrettyTable 
+
+def isIntN(x, n):
+    limit = (1 << (n-1))
+    return -limit <= x < limit
+
+def isUIntN(x, n):
+    return (x >> n) == 0
+
+class Instruction:
+    
+    def __init__(self, line, pc, insnHex, insn, operands, offset):
+        self.line = line
+        self.pc = pc
+        self.insnHex = insnHex
+        self.insn = insn
+        self.operands = operands
+        self.offset = offset
+
+    def __repr__(self):
+        return f"{self.pc:x} {self.insnHex:08x} {self.insn} {','.join(self.operands)}"
+
+    def __is3BitReg(self, reg):
+        return bool(re.match(r'^f?(s[01]|a[0-5])$', reg))
+
+    def __checkConstraint(self, fn):
+        return fn(*self.operands)
+
+    def isConvertible(self):
+        if self.insn in ['nop', 'ebreak', 'mv']:
+            return True
+        if self.insn in ['lw', 'flw', 'sw', 'fsw']:
+            return self.__checkConstraint(lambda rd, offset, rs: 
+                                            rs == 'sp'
+                                            and isUIntN(int(offset), 8)
+                                            and (int(offset) & 0x3) == 0)
+        if self.insn in ['ld', 'fld', 'sd', 'fsd']:
+            return self.__checkConstraint(lambda rd, offset, rs: 
+                                            rs == 'sp'
+                                            and isUIntN(int(offset), 9)
+                                            and (int(offset) & 0x7) == 0)
+        if self.insn in ['jalr', 'jr']:
+            return len(self.operands) == 1
+        if self.insn in ['jal', 'j']:
+            return len(self.operands) == 1 \
+                and self.__checkConstraint(lambda offset: 
+                                            isUIntN(int(offset), 12)
+                                            and (int(offset) & 0x1) == 0)
+        if self.insn in ['beq', 'bne']:
+            return self.__checkConstraint(lambda rs1, rs2, offset: 
+                                            rs2 == 'zero_reg'
+                                            and self.__is3BitReg(rs1) \
+                                            and isIntN(int(offset), 9)
+                                            and (int(offset) & 0x1) == 0)
+        if self.insn in ['and', 'or', 'xor', 'sub', 'andw', 'subw']:
+            return self.__checkConstraint(lambda rd, rs1, rs2: 
+                                            rd == rs1 \
+                                            and self.__is3BitReg(rd) \
+                                            and self.__is3BitReg(rs2))
+        if self.insn in ['andi']:
+            return self.__checkConstraint(lambda rd, rs, imm: rd == rs \
+                                                        and self.__is3BitReg(rd) \
+                                                        and isIntN(int(imm, 16), 6))
+        if self.insn in ['li']:
+            return self.__checkConstraint(lambda rd, imm: isIntN(int(imm), 6))
+        if self.insn in ['lui']:
+            return self.__checkConstraint(lambda rd, imm: 
+                                            (rd != 'zero_reg' or rd != 'sp')
+                                            and isUIntN(int(imm, 16), 6))
+        if self.insn in ['slli']:
+            return self.__checkConstraint(lambda rd, rs, shamt: 
+                                            rd == rs
+                                            and isUIntN(int(shamt), 6))
+        if self.insn in ['srli', 'srai']:
+            return self.__checkConstraint(lambda rd, rs, shamt: 
+                                            rd == rs
+                                            and self.__is3BitReg(rd)
+                                            and isUIntN(int(shamt), 6))
+        if self.insn in ['add']:
+            return self.__checkConstraint(lambda rd, rs1, rs2: rd == rs1)
+        if self.insn in ['addi']:
+            return self.__checkConstraint(lambda rd, rs, imm: 
+                                            # C.ADDI
+                                            (rd == rs and isIntN(int(imm), 6))
+                                            # C.ADDI16SP
+                                            or (rd == rs and rd == 'sp' 
+                                                and isIntN(int(imm), 10) 
+                                                and (int(imm) & 0xF == 0))
+                                            # C.ADDI4SPN
+                                            or (self.__is3BitReg(rd)
+                                                and rs == 'sp'
+                                                and isUIntN(int(imm), 10)
+                                                and (int(imm) & 0x3) == 0))
+        if self.insn in ['addiw']:
+            return self.__checkConstraint(lambda rd, rs, imm: rd == rs 
+                                                        and isIntN(int(imm), 6))
+        if self.insn in ['sext.w']:
+            return self.__checkConstraint(lambda rd, rs: rd == rs)
+                                                       
+        return False
+
+    def insnSize(self):
+        return 32 if self.insnHex & 0x3 == 0x3 else 16
+
+    def isShort(self):
+        return self.insnSize() == 16
+
+    # Create an Instruction from a line of the code dump, or if it
+    # does not look like an instruction, return None
+    # A normal instruction looks like:
+    #  0x55a1aa324b38   178  00008393       mv        t2, ra
+    @classmethod
+    def fromLine(cls, line):
+        words = line.split()
+        if len(words) < 4:
+            return None
+        pc = None
+        offset = None
+        insnHex = None
+        try:
+            pc = int(words[0], 16)
+            offset = int(words[1], 16)
+            insnHex = int(words[2], 16)
+        except ValueError:
+            pass
+        if pc is None or offset is None or insnHex is None:
+            return None
+
+        insn = words[3]
+        operands = []
+        for idx in range(4, len(words)):
+            word = words[idx]
+            parts = re.split('[\(\)]', word)
+            for part in parts:
+                if len(part) > 0:
+                    operands.append(part.strip(','))
+            if not word.endswith(','):
+                # This is the last operand
+                break
+        return cls(line, pc, insnHex, insn, operands, offset) if insn != 'constant' else None
+
+def printTable(lst):
+    if len(lst) == 0:
+        print("---- No Generated Code ----")
+        return
+
+    summary = PrettyTable(["Summary", "All Instr", "Convertible", "Ratio"])
+    cnt1 = sum([x[1] for x in lst])
+    cnt2 = sum([x[2] for x in lst])
+    summary.add_row(["", cnt1, cnt2, "{:.2%}".format(float(cnt2) / cnt1)])
+    print(summary)
+
+    tbl = PrettyTable(["Instruction", "Total", "Convertible", "Ratio"])
+    for x in lst:
+        row = [x[0], x[1], x[2], "{:.2%}".format(float(x[2]) / x[1])]
+        tbl.add_row(row)
+    print(tbl)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbose', action='store_true', default=False,
+                        dest='verbose', help='print all convertible instructions')
+    parser.add_argument('logfile', nargs=1)
+    args = parser.parse_args()
+
+    startTime = time.time()
+    rawCounter = Counter()
+    convertibleCounter = Counter()
+
+    logfile = open(args.logfile[0])
+    nextLine = logfile.readline()
+    if args.verbose:
+        print("Convertible Instructions:")
+    while nextLine:
+        line = nextLine
+        nextLine = logfile.readline()
+
+        words = line.split()
+        if len(words) == 0:
+            continue
+        
+        insn = Instruction.fromLine(line)
+        if insn is not None and not insn.isShort():
+            rawCounter[insn.insn] += 1
+            try: 
+                if insn.isConvertible():
+                    if args.verbose:
+                        print(line, end = '')
+                    convertibleCounter[insn.insn] += 1
+            except BaseException:
+                print("Error Line: ", line, end = '')
+    logfile.close()
+
+    result = [(x, rawCounter[x], convertibleCounter[x]) for x in convertibleCounter]
+    result.sort(key=lambda x: -x[2])
+    print()
+    printTable(result)
+    print('time cost -- {:.2f}s'.format(time.time() - startTime))


### PR DESCRIPTION
linked issue #284 

This tool collects statistics on instructions from dump file with the flags `--print-all-code` or `--print-code`

```
$ ./v8-riscv-tools/collect-convertible.py -h
usage: collect-convertible.py [-h] [-v] logfile

positional arguments:
  logfile

optional arguments:
  -h, --help     show this help message and exit
  -v, --verbose  print all convertible instructions
```

i.e. In this example, the result statistics is all about bulit-in functions. Because I got no input with the flag `--print-code`.
```
$ out/riscv64.sim/cctest --print-all-code test-interpreter-intrinsics/Call &> out.log

$ ./v8-riscv-tools/collect-convertible.py out.log
Error Line:  0x55f5f83bafb0   3f0  5e099263       bne       s3, zero_reg,

Error Line:  0x55f5f83bbbd0   3f0  5e099663       bne       s3, zero_reg,

+---------+-----------+-------------+--------+
| Summary | All Instr | Convertible | Ratio  |
+---------+-----------+-------------+--------+
|         |  2241572  |   1068507   | 47.67% |
+---------+-----------+-------------+--------+
+-------------+--------+-------------+---------+
| Instruction | Total  | Convertible |  Ratio  |
+-------------+--------+-------------+---------+
|     add     | 212880 |    206067   |  96.80% |
|     lui     | 245702 |    200560   |  81.63% |
|      mv     | 198599 |    198599   | 100.00% |
|     jalr    | 140542 |    84155    |  59.88% |
|     slli    | 96596  |    78591    |  81.36% |
|     addi    | 340083 |    76097    |  22.38% |
|      sd     | 280387 |    69874    |  24.92% |
|      ld     | 465930 |    62536    |  13.42% |
|    ebreak   | 41229  |    41229    | 100.00% |
|      li     | 46550  |    31279    |  67.19% |
|      j      | 11379  |     4586    |  40.30% |
|      jr     |  3124  |     3124    | 100.00% |
|     srai    |  4594  |     2221    |  48.35% |
|     andi    | 65301  |     1622    |  2.48%  |
|     xor     |  6974  |     1381    |  19.80% |
|     nop     |  1354  |     1354    | 100.00% |
|      or     |  6506  |     1273    |  19.57% |
|     srli    |  1457  |     1000    |  68.63% |
|    sext.w   |  5702  |     603     |  10.58% |
|    addiw    |  1065  |     493     |  46.29% |
|     beq     | 19600  |     440     |  2.24%  |
|     fsd     |  2077  |     402     |  19.35% |
|     bne     | 24980  |     381     |  1.53%  |
|     and     |  7465  |     312     |  4.18%  |
|     sub     |  1819  |     181     |  9.95%  |
|     fld     |  3089  |     144     |  4.66%  |
|      lw     |  3078  |      2      |  0.06%  |
|      sw     |  3510  |      1      |  0.03%  |
+-------------+--------+-------------+---------+
time cost -- 17.52s
```
In this one, the result is about the generated code.

```
$ out/riscv64.sim/d8 --print-code test/benchmarks/data/sunspider/3d-cube.js > sunspider-3d-cube.out.log

$ ./v8-riscv-tools/collect-convertible.py sunspider-3d-cube.out.log

+---------+-----------+-------------+--------+
| Summary | All Instr | Convertible | Ratio  |
+---------+-----------+-------------+--------+
|         |    2649   |     1503    | 56.74% |
+---------+-----------+-------------+--------+
+-------------+-------+-------------+---------+
| Instruction | Total | Convertible |  Ratio  |
+-------------+-------+-------------+---------+
|     slli    |  911  |     786     |  86.28% |
|     jalr    |  325  |     220     |  67.69% |
|      li     |  222  |     176     |  79.28% |
|      mv     |  134  |     134     | 100.00% |
|     addi    |  452  |      69     |  15.27% |
|      sd     |  214  |      68     |  31.78% |
|      ld     |  269  |      22     |  8.18%  |
|      j      |   47  |      12     |  25.53% |
|      jr     |   4   |      4      | 100.00% |
|     nop     |   4   |      4      | 100.00% |
|     srai    |   11  |      3      |  27.27% |
|     andi    |   37  |      2      |  5.41%  |
|     add     |   15  |      2      |  13.33% |
|     srli    |   4   |      1      |  25.00% |
+-------------+-------+-------------+---------+
time cost -- 0.05s
```