### PR TITLE
Fix #317.

### DIFF
--- a/src/codegen/riscv64/assembler-riscv64.cc
+++ b/src/codegen/riscv64/assembler-riscv64.cc
@@ -227,6 +227,15 @@ Assembler::Assembler(const AssemblerOptions& options,
 void Assembler::GetCode(Isolate* isolate, CodeDesc* desc,
                         SafepointTableBuilder* safepoint_table_builder,
                         int handler_table_offset) {
+  // As a crutch to avoid having to add manual Align calls wherever we use a
+  // raw workflow to create Code objects (mostly in tests), add another Align
+  // call here. It does no harm - the end of the Code object is aligned to the
+  // (larger) kCodeAlignment anyways.
+  // TODO(jgruber): Consider moving responsibility for proper alignment to
+  // metadata table builders (safepoint, handler, constant pool, code
+  // comments).
+  DataAlign(Code::kMetadataAlignment);
+
   ForceConstantPoolEmissionWithoutJump();
 
   int code_comments_size = WriteCodeComments();


### PR DESCRIPTION
Fix #317.

Refer to 146c9708b558836ab4d9eadc75ea377ba2b89d60.

Before:

```
cctest/test-assembler-riscv64/RVC_CA default: FAIL
cctest/test-assembler-riscv64/RVC_CI default: FAIL
cctest/test-assembler-riscv64/RVC_CIW default: FAIL
cctest/test-assembler-riscv64/RVC_CR default: FAIL
cctest/test-assembler-riscv64/RVC_JUMP default: FAIL
cctest/test-assembler-riscv64/RVC_LOAD_STORE_COMPRESSED default: FAIL
cctest/test-assembler-riscv64/RVC_LOAD_STORE_SP default: pass
```

After:
```
cctest/test-assembler-riscv64/RVC_CA default: pass
cctest/test-assembler-riscv64/RVC_CI default: pass
cctest/test-assembler-riscv64/RVC_CIW default: pass
cctest/test-assembler-riscv64/RVC_CR default: pass
cctest/test-assembler-riscv64/RVC_JUMP default: pass
cctest/test-assembler-riscv64/RVC_LOAD_STORE_COMPRESSED default: pass
cctest/test-assembler-riscv64/RVC_LOAD_STORE_SP default: pass
```