### PR TITLE
Skip test that frequently fails due to timing issue

### DIFF
--- a/test/mjsunit/mjsunit.status
+++ b/test/mjsunit/mjsunit.status
@@ -819,6 +819,9 @@
 
   'wasm/memory_2gb_oob': [SKIP], # OOM: sorry, best effort max memory size test
   'wasm/memory_4gb_oob': [SKIP], # OOM: sorry, best effort max memory size test
+
+  # This often fails in debug mode because it is too slow
+  'd8/d8-performance-now': [PASS, ['mode == debug', SKIP]],
 }],  # 'arch == riscv64 or arch == riscv'
 
 ##############################################################################


### PR DESCRIPTION
This test often fails in debug mode because it is too slow. The error
would look something like:

```
Timer difference too big: 1.8240000000000691ms
Timer difference too big: 1.893000000000029ms
Timer difference too big: 1.8870000000000573ms
Timer difference too big: 1.8909999999999627ms
Timer difference too big: 1.8869999999999436ms
Timer difference too big: 1.8960000000000719ms
Timer difference too big: 1.884999999999991ms
test/mjsunit/mjsunit.js:316: Failure: expected <true> found <false>
```