### PR TITLE
Move define of DEBUG_PRINTF from macros.h to RISCV64 specific header.

### DIFF
--- a/src/base/macros.h
+++ b/src/base/macros.h
@@ -12,16 +12,6 @@
 #include "src/base/logging.h"
 #include "src/base/platform/wrappers.h"
 
-#define DEBUG_PRINTF(...) \
-  if (FLAG_debug_riscv) { \
-    printf(__VA_ARGS__);  \
-  }
-
-#define DEBUG_PRINTF(...) \
-  if (FLAG_debug_riscv) { \
-    printf(__VA_ARGS__);  \
-  }
-
 // No-op macro which is used to work around MSVC's funky VA_ARGS support.
 #define EXPAND(x) x
 

--- a/src/codegen/riscv64/assembler-riscv64.h
+++ b/src/codegen/riscv64/assembler-riscv64.h
@@ -52,6 +52,11 @@
 namespace v8 {
 namespace internal {
 
+#define DEBUG_PRINTF(...) \
+  if (FLAG_debug_riscv) { \
+    printf(__VA_ARGS__);  \
+  }
+
 class SafepointTableBuilder;
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Refer to:
https://chromium-review.googlesource.com/c/v8/v8/+/2571344/8/src/base/macros.h#16