### PR TITLE
Remove unused and incomplete `simd_riscv` flag

### DIFF
--- a/src/flags/flag-definitions.h
+++ b/src/flags/flag-definitions.h
@@ -1203,7 +1203,8 @@ DEFINE_STRING(sim_arm64_optional_features, "none",
               "all")
 DEFINE_BOOL(debug_riscv, false, "enable debug prints")
 // FIXME(Riscv): (https://github.com/v8-riscv/v8/issues/330)
-DEFINE_BOOL(disable_riscv_constant_pool, true, "disable constant pool (RISCV only)")
+DEFINE_BOOL(disable_riscv_constant_pool, true,
+            "disable constant pool (RISCV only)")
 
 // Controlling source positions for Torque/CSA code.
 DEFINE_BOOL(enable_source_at_csa_bind, false,

--- a/tools/testrunner/base_runner.py
+++ b/tools/testrunner/base_runner.py
@@ -629,11 +629,6 @@ class BaseTestRunner(object):
       self.build_config.mips_arch_variant == "r6" and
       self.build_config.mips_use_msa)
 
-    # FIXME (RISCV): add sim_riscv flags in base_runner.py
-    simd_riscv = False
-      # (self.build_config.arch in ['riscv', 'riscv64'] and
-      # self.build_config.riscv_use_simd)
-
     mips_arch_variant = (
       self.build_config.arch in ['mipsel', 'mips', 'mips64', 'mips64el'] and
       self.build_config.mips_arch_variant)
@@ -662,7 +657,6 @@ class BaseTestRunner(object):
       "optimize_for_size": "--optimize-for-size" in options.extra_flags,
       "predictable": self.build_config.predictable,
       "simd_mips": simd_mips,
-      "simd_riscv": simd_riscv,
       "simulator_run": self.build_config.simulator_run and
                        not options.dont_skip_simulator_slow_tests,
       "system": self.target_os,


### PR DESCRIPTION
This may be re-added lateralong with the other architecural flags.

See #98