### PR TITLE
Add riscv64 to the "disable_arguments adaptor" group

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -114,7 +114,7 @@ declare_args() {
       v8_current_cpu == "x86" || v8_current_cpu == "x64" ||
       v8_current_cpu == "arm" || v8_current_cpu == "arm64" ||
       v8_current_cpu == "mipsel" || v8_current_cpu == "mips64el" ||
-      v8_current_cpu == "ppc64" || v8_current_cpu == "s390x"  ||
+      v8_current_cpu == "ppc64" || v8_current_cpu == "s390x" ||
       v8_current_cpu == "riscv64"
 
   # Sets -dOBJECT_PRINT.

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -114,7 +114,8 @@ declare_args() {
       v8_current_cpu == "x86" || v8_current_cpu == "x64" ||
       v8_current_cpu == "arm" || v8_current_cpu == "arm64" ||
       v8_current_cpu == "mipsel" || v8_current_cpu == "mips64el" ||
-      v8_current_cpu == "ppc64" || v8_current_cpu == "s390x"
+      v8_current_cpu == "ppc64" || v8_current_cpu == "s390x"  ||
+      v8_current_cpu == "riscv64"
 
   # Sets -dOBJECT_PRINT.
   v8_enable_object_print = ""

--- a/src/builtins/riscv64/builtins-riscv64.cc
+++ b/src/builtins/riscv64/builtins-riscv64.cc
@@ -788,9 +788,9 @@ static void LeaveInterpreterFrame(MacroAssembler* masm, Register scratch1,
 
   // If actual is bigger than formal, then we should use it to free up the stack
   // arguments.
-  __ Branch(&L1, le, actual_params_size, params_size);
+  __ Branch(&L1, le, actual_params_size, Operand(params_size));
   __ Move(params_size, actual_params_size);
-  __ bind(L1);
+  __ bind(&L1);
 #endif
 
   // Leave the frame (also dropping the register file).

--- a/src/codegen/riscv64/macro-assembler-riscv64.cc
+++ b/src/codegen/riscv64/macro-assembler-riscv64.cc
@@ -3437,8 +3437,8 @@ void MacroAssembler::InvokePrologue(Register expected_parameter_count,
     Ld(t1, MemOperand(src, 0));
     Sd(t1, MemOperand(dest, 0));
     Sub64(t0, t0, Operand(1));
-    Sub64(src, src, Operand(kSystemPointerSize));
-    Sub64(dest, dest, Operand(kSystemPointerSize));
+    Add64(src, src, Operand(kSystemPointerSize));
+    Add64(dest, dest, Operand(kSystemPointerSize));
     Branch(&copy, ge, t0, Operand(zero_reg));
   }
 


### PR DESCRIPTION
1. Enable the V8_NO_ARGUMENTS_ADAPTOR for RISCV64 backend
2. Fix typos for V8_NO_ARGUMENTS_ADAPTOR code