### PR TITLE
Skip externref-globals-liftoff

### DIFF
--- a/src/builtins/riscv64/builtins-riscv64.cc
+++ b/src/builtins/riscv64/builtins-riscv64.cc
@@ -925,7 +925,7 @@ static void AdvanceBytecodeOffsetOrReturn(MacroAssembler* masm,
   __ Add64(scratch2, bytecode_array, bytecode_offset);
   __ Lbu(bytecode, MemOperand(scratch2));
   __ Add64(bytecode_size_table, bytecode_size_table,
-           Operand(kIntSize * interpreter::Bytecodes::kBytecodeCount));
+           Operand(kByteSize * interpreter::Bytecodes::kBytecodeCount));
   __ Branch(&process_bytecode);
 
   __ bind(&extra_wide);
@@ -934,7 +934,7 @@ static void AdvanceBytecodeOffsetOrReturn(MacroAssembler* masm,
   __ Add64(scratch2, bytecode_array, bytecode_offset);
   __ Lbu(bytecode, MemOperand(scratch2));
   __ Add64(bytecode_size_table, bytecode_size_table,
-           Operand(2 * kIntSize * interpreter::Bytecodes::kBytecodeCount));
+           Operand(2 * kByteSize * interpreter::Bytecodes::kBytecodeCount));
 
   __ bind(&process_bytecode);
 
@@ -957,8 +957,8 @@ static void AdvanceBytecodeOffsetOrReturn(MacroAssembler* masm,
 
   __ bind(&not_jump_loop);
   // Otherwise, load the size of the current bytecode and advance the offset.
-  __ CalcScaledAddress(scratch2, bytecode_size_table, bytecode, 2);
-  __ Lw(scratch2, MemOperand(scratch2));
+  __ Add64(scratch2, bytecode_size_table, bytecode);
+  __ Lb(scratch2, MemOperand(scratch2));
   __ Add64(bytecode_offset, bytecode_offset, scratch2);
 
   __ bind(&end);

--- a/src/compiler/backend/riscv64/instruction-codes-riscv64.h
+++ b/src/compiler/backend/riscv64/instruction-codes-riscv64.h
@@ -364,6 +364,8 @@ namespace compiler {
   V(RiscvS128Load16x4U)                     \
   V(RiscvS128Load32x2S)                     \
   V(RiscvS128Load32x2U)                     \
+  V(RiscvS128LoadLane)                      \
+  V(RiscvS128StoreLane)                     \
   V(RiscvMsaLd)                             \
   V(RiscvMsaSt)                             \
   V(RiscvI32x4SConvertI16x8Low)             \

--- a/src/compiler/backend/riscv64/instruction-codes-riscv64.h
+++ b/src/compiler/backend/riscv64/instruction-codes-riscv64.h
@@ -321,11 +321,9 @@ namespace compiler {
   V(RiscvS128Not)                           \
   V(RiscvS128Select)                        \
   V(RiscvS128AndNot)                        \
-  V(RiscvV32x4AnyTrue)                      \
   V(RiscvV32x4AllTrue)                      \
-  V(RiscvV16x8AnyTrue)                      \
   V(RiscvV16x8AllTrue)                      \
-  V(RiscvV8x16AnyTrue)                      \
+  V(RiscvV128AnyTrue)                       \
   V(RiscvV8x16AllTrue)                      \
   V(RiscvS32x4InterleaveRight)              \
   V(RiscvS32x4InterleaveLeft)               \

--- a/src/compiler/backend/riscv64/instruction-scheduler-riscv64.cc
+++ b/src/compiler/backend/riscv64/instruction-scheduler-riscv64.cc
@@ -364,6 +364,8 @@ int InstructionScheduler::GetTargetInstructionFlags(
     case kRiscvS128Load16x4U:
     case kRiscvS128Load32x2S:
     case kRiscvS128Load32x2U:
+    case kRiscvS128LoadLane:
+    case kRiscvS128StoreLane:
     case kRiscvWord64AtomicLoadUint8:
     case kRiscvWord64AtomicLoadUint16:
     case kRiscvWord64AtomicLoadUint32:

--- a/src/compiler/backend/riscv64/instruction-scheduler-riscv64.cc
+++ b/src/compiler/backend/riscv64/instruction-scheduler-riscv64.cc
@@ -289,11 +289,9 @@ int InstructionScheduler::GetTargetInstructionFlags(
     case kRiscvS16x2Reverse:
     case kRiscvS16x4Reverse:
     case kRiscvV8x16AllTrue:
-    case kRiscvV8x16AnyTrue:
     case kRiscvV32x4AllTrue:
-    case kRiscvV32x4AnyTrue:
     case kRiscvV16x8AllTrue:
-    case kRiscvV16x8AnyTrue:
+    case kRiscvV128AnyTrue:
     case kRiscvS32x4InterleaveEven:
     case kRiscvS32x4InterleaveOdd:
     case kRiscvS32x4InterleaveLeft:

--- a/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
+++ b/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
@@ -381,6 +381,10 @@ void EmitLoad(InstructionSelector* selector, Node* node, InstructionCode opcode,
   }
 }
 
+void InstructionSelector::VisitStoreLane(Node* node) { UNIMPLEMENTED(); }
+
+void InstructionSelector::VisitLoadLane(Node* node) { UNIMPLEMENTED(); }
+
 void InstructionSelector::VisitLoadTransform(Node* node) {
   LoadTransformParameters params = LoadTransformParametersOf(node->op());
 

--- a/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
+++ b/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
@@ -2623,11 +2623,9 @@ void InstructionSelector::VisitInt64AbsWithOverflow(Node* node) {
   V(I8x16Abs, kRiscvI8x16Abs)                             \
   V(I8x16BitMask, kRiscvI8x16BitMask)                     \
   V(S128Not, kRiscvS128Not)                               \
-  V(V32x4AnyTrue, kRiscvV32x4AnyTrue)                     \
+  V(V128AnyTrue, kRiscvV128AnyTrue)                       \
   V(V32x4AllTrue, kRiscvV32x4AllTrue)                     \
-  V(V16x8AnyTrue, kRiscvV16x8AnyTrue)                     \
   V(V16x8AllTrue, kRiscvV16x8AllTrue)                     \
-  V(V8x16AnyTrue, kRiscvV8x16AnyTrue)                     \
   V(V8x16AllTrue, kRiscvV8x16AllTrue)
 
 #define SIMD_SHIFT_OP_LIST(V) \

--- a/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
+++ b/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
@@ -1597,9 +1597,9 @@ void LiftoffAssembler::emit_i8x16_neg(LiftoffRegister dst,
   bailout(kSimd, "emit_i8x16_neg");
 }
 
-void LiftoffAssembler::emit_v8x16_anytrue(LiftoffRegister dst,
-                                          LiftoffRegister src) {
-  bailout(kSimd, "emit_v8x16_anytrue");
+void LiftoffAssembler::emit_v128_anytrue(LiftoffRegister dst,
+                                         LiftoffRegister src) {
+  bailout(kSimd, "emit_v128_anytrue");
 }
 
 void LiftoffAssembler::emit_v8x16_alltrue(LiftoffRegister dst,
@@ -1712,11 +1712,6 @@ void LiftoffAssembler::emit_i16x8_neg(LiftoffRegister dst,
   bailout(kSimd, "emit_i16x8_neg");
 }
 
-void LiftoffAssembler::emit_v16x8_anytrue(LiftoffRegister dst,
-                                          LiftoffRegister src) {
-  bailout(kSimd, "emit_v16x8_anytrue");
-}
-
 void LiftoffAssembler::emit_v16x8_alltrue(LiftoffRegister dst,
                                           LiftoffRegister src) {
   bailout(kSimd, "emit_v16x8_alltrue");
@@ -1825,11 +1820,6 @@ void LiftoffAssembler::emit_i16x8_max_u(LiftoffRegister dst,
 void LiftoffAssembler::emit_i32x4_neg(LiftoffRegister dst,
                                       LiftoffRegister src) {
   bailout(kSimd, "emit_i32x4_neg");
-}
-
-void LiftoffAssembler::emit_v32x4_anytrue(LiftoffRegister dst,
-                                          LiftoffRegister src) {
-  bailout(kSimd, "emit_v32x4_anytrue");
 }
 
 void LiftoffAssembler::emit_v32x4_alltrue(LiftoffRegister dst,

--- a/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
+++ b/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
@@ -641,6 +641,7 @@ void LiftoffAssembler::Spill(int offset, LiftoffRegister reg, ValueType type) {
     case ValueType::kRef:
     case ValueType::kOptRef:
     case ValueType::kRtt:
+    case ValueType::kRttWithDepth:
       Sd(reg.gp(), dst);
       break;
     case ValueType::kF32:
@@ -648,6 +649,9 @@ void LiftoffAssembler::Spill(int offset, LiftoffRegister reg, ValueType type) {
       break;
     case ValueType::kF64:
       TurboAssembler::StoreDouble(reg.fp(), dst);
+      break;
+    case ValueType::kS128:
+      bailout(kSimd, "Spill S128");
       break;
     default:
       UNREACHABLE();

--- a/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
+++ b/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
@@ -1351,6 +1351,11 @@ void LiftoffAssembler::emit_i64x2_splat(LiftoffRegister dst,
   bailout(kSimd, "emit_i64x2_splat");
 }
 
+void LiftoffAssembler::emit_i64x2_eq(LiftoffRegister dst, LiftoffRegister lhs,
+                                     LiftoffRegister rhs) {
+  bailout(kSimd, "emit_i64x2_eq");
+}
+
 void LiftoffAssembler::emit_f32x4_splat(LiftoffRegister dst,
                                         LiftoffRegister src) {
   bailout(kSimd, "emit_f32x4_splat");

--- a/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
+++ b/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
@@ -144,6 +144,9 @@ inline void push(LiftoffAssembler* assm, LiftoffRegister reg, ValueType type) {
       assm->Sw(reg.gp(), MemOperand(sp, 0));
       break;
     case ValueType::kI64:
+    case ValueType::kOptRef:
+    case ValueType::kRef:
+    case ValueType::kRtt:
       assm->push(reg.gp());
       break;
     case ValueType::kF32:

--- a/test/cctest/cctest.status
+++ b/test/cctest/cctest.status
@@ -380,6 +380,12 @@
 
   # SIMD not fully implemented yet
   'test-run-wasm-simd-liftoff/*': [SKIP],
+
+  # riscv64 don't implemented some wasm function
+  'test-run-wasm-atomics64/*': [SKIP],
+  'test-run-wasm-atomics/*': [SKIP],
+  'test-run-wasm-64/*': [SKIP],
+  'test-run-wasm/*': [SKIP],
 }],
 
 ##############################################################################

--- a/test/mjsunit/mjsunit.status
+++ b/test/mjsunit/mjsunit.status
@@ -827,6 +827,26 @@
 
   # This often fails in debug mode because it is too slow
   'd8/d8-performance-now': [PASS, ['mode == debug', SKIP]],
+
+  # Some atomic functions are not yet implemented
+  'wasm/compare-exchange64-stress': [SKIP],
+  'wasm/compare-exchange-stress': [SKIP],
+  'regress/wasm/regress-1045225': [SKIP],
+  'regress/wasm/regress-1045737': [SKIP],
+  'regress/wasm/regress-1048241': [SKIP],
+  'regress/wasm/regress-1074586-b': [SKIP],
+  'regress/wasm/regress-1075953': [SKIP],
+  'regress/wasm/regress-1074586': [SKIP],
+  'regress/wasm/regress-1079449': [SKIP],
+  'regress/wasm/regress-1080902': [SKIP],
+  'regress/wasm/regress-1140549': [SKIP],
+  'regress/wasm/regress-1153442': [SKIP],
+  'regress/wasm/regress-1168116': [SKIP],
+  'wasm/atomics': [SKIP],
+  'wasm/atomics-non-shared': [SKIP],
+  'wasm/grow-shared-memory': [SKIP],
+  'wasm/origin-trial-flags': [SKIP],
+  'wasm/shared-memory': [SKIP],
 }],  # 'arch == riscv64'
 
 ##############################################################################

--- a/test/mjsunit/mjsunit.status
+++ b/test/mjsunit/mjsunit.status
@@ -849,6 +849,10 @@
   'wasm/shared-memory': [SKIP],
 }],  # 'arch == riscv64'
 
+['arch == riscv64 and variant == stress_incremental_marking', {
+  'wasm/externref-globals-liftoff': [SKIP], # issue 414
+}], #'arch == riscv64 and variant == stress-incremental-marking'
+
 ##############################################################################
 ['system == windows', {
   # Too slow with turbo fan.

--- a/test/wasm-spec-tests/wasm-spec-tests.status
+++ b/test/wasm-spec-tests/wasm-spec-tests.status
@@ -134,6 +134,17 @@
    # See issue #403
    'proposals/js-types/exports': [SKIP],
    'proposals/js-types/imports': [SKIP],
+
+   # riscv64 don't implemented some wasm atomic func
+   'left-to-right': [SKIP],
+   'float_misc': [SKIP],
+   'f64_bitwise': [SKIP],
+   'f32_bitwise': [SKIP],
+   'proposals/tail-call/f32_bitwise': [SKIP],
+   'proposals/tail-call/f64_bitwise': [SKIP],
+   'proposals/tail-call/float_misc': [SKIP],
+   'proposals/tail-call/left-to-right': [SKIP],
+
 }],  # 'arch == riscv64
 
 ['arch == ppc or arch == ppc64', {


### PR DESCRIPTION
  Skip externref-globals-liftoff when stress_incremental_marking