### PR TITLE
Optimization #455.

### DIFF
--- a/src/codegen/riscv64/assembler-riscv64.cc
+++ b/src/codegen/riscv64/assembler-riscv64.cc
@@ -2565,12 +2565,19 @@ void Assembler::AdjustBaseAndOffset(MemOperand* src, Register scratch,
   // for a load/store when the offset doesn't fit into int12.
 
   // Must not overwrite the register 'base' while loading 'offset'.
-  DCHECK(src->rm() != scratch);
 
-  RV_li(scratch, src->offset());
-  add(scratch, scratch, src->rm());
-  src->offset_ = 0;
-  src->rm_ = scratch;
+  DCHECK(src->rm() != scratch);
+  if(access_type == OffsetAccessType::SINGLE_ACCESS) {
+    RV_li(scratch, (src->offset() + 0x800) >>12 <<12);
+    add(scratch, scratch, src->rm());
+    src->offset_ = src->offset() <<20 >>20;
+    src->rm_ = scratch;
+  } else {
+    RV_li(scratch, src->offset());
+    add(scratch, scratch, src->rm());
+    src->offset_ = 0;
+    src->rm_ = scratch;
+  }
 }
 
 int Assembler::RelocateInternalReference(RelocInfo::Mode rmode, Address pc,

--- a/src/deoptimizer/riscv64/deoptimizer-riscv64.cc
+++ b/src/deoptimizer/riscv64/deoptimizer-riscv64.cc
@@ -8,9 +8,9 @@ namespace v8 {
 namespace internal {
 
 const bool Deoptimizer::kSupportsFixedDeoptExitSizes = true;
-const int Deoptimizer::kNonLazyDeoptExitSize = 5 * kInstrSize;
-const int Deoptimizer::kLazyDeoptExitSize = 5 * kInstrSize;
-const int Deoptimizer::kEagerWithResumeBeforeArgsSize = 6 * kInstrSize;
+const int Deoptimizer::kNonLazyDeoptExitSize = 4 * kInstrSize;
+const int Deoptimizer::kLazyDeoptExitSize = 4 * kInstrSize;
+const int Deoptimizer::kEagerWithResumeBeforeArgsSize = 5 * kInstrSize;
 const int Deoptimizer::kEagerWithResumeDeoptExitSize =
     kEagerWithResumeBeforeArgsSize + 4 * kInstrSize;
 const int Deoptimizer::kEagerWithResumeImmedArgs1PcOffset = kInstrSize;


### PR DESCRIPTION
Take advantage of the 12 bit offset field of load/store instructions.
